### PR TITLE
[QC][TLE] Support cross-dtype Hopper WGMMA accumulator reuse

### DIFF
--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/DotOpToLLVM/WGMMA.cpp
@@ -216,7 +216,75 @@ LogicalResult convertDot(const LLVMTypeConverter *typeConverter,
   auto baseB = getOffsetedBase(loadedB, cast<MemDescType>(bTensorTy),
                                typeConverter, rewriter, loc);
   auto dShapePerCTA = getShapePerCTA(dTensorTy);
-  auto instrMNK = mmaEncoding.getInstrShape();
+  auto instructionMmaEncoding = mmaEncoding;
+#ifdef __TLE__
+  // An async accumulator chain may cross WGMMA operand types. Hopper's C
+  // register ownership depends on M/N and the warp/CTA distribution, not K.
+  // TLE keeps the preceding dot's encoding on the async C value, while a
+  // register-A operand carries the instruction shape required by the current
+  // dtype. Use that shape only when both encodings describe the same physical
+  // C register layout.
+  if (auto aDotEncoding =
+          dyn_cast<DotOperandEncodingAttr>(aTensorTy.getEncoding())) {
+    if (auto aMmaEncoding =
+            dyn_cast<NvidiaMmaEncodingAttr>(aDotEncoding.getParent())) {
+      if (aMmaEncoding != mmaEncoding) {
+        auto accInstrShape = mmaEncoding.getInstrShape();
+        auto currentInstrShape = aMmaEncoding.getInstrShape();
+        bool compatibleCLayout =
+            mmaEncoding.isHopper() && aMmaEncoding.isHopper() &&
+            accInstrShape[0] == currentInstrShape[0] &&
+            accInstrShape[1] == currentInstrShape[1] &&
+            mmaEncoding.getWarpsPerCTA() == aMmaEncoding.getWarpsPerCTA() &&
+            mmaEncoding.getCTALayout() == aMmaEncoding.getCTALayout();
+        if (compatibleCLayout) {
+          instructionMmaEncoding = aMmaEncoding;
+        } else if (op->hasAttr(kTleWgmmaAccumulatorChainCAttr)) {
+          op->emitError("cannot reuse an async WGMMA accumulator across "
+                        "incompatible physical C layouts");
+          return failure();
+        }
+      }
+    }
+  }
+#endif
+  auto instructionShape = instructionMmaEncoding.getInstrShape();
+  SmallVector<unsigned> instrMNK;
+  instrMNK.reserve(instructionShape.size());
+  for (int64_t dim : instructionShape)
+    instrMNK.push_back(static_cast<unsigned>(dim));
+#ifdef __TLE__
+  // Shared-A has no dot-operand parent encoding from which to recover the
+  // current instruction K. Infer only K from the current shared operand dtype;
+  // M/N and physical C ownership remain those of the result encoding. This is
+  // a no-op for ordinary same-dtype dots and changes only a stale cross-dtype
+  // K (for example FP8/K32 C followed by BF16/K16 shared/shared operands).
+  if (aInShared) {
+    auto instructionKForType = [&](Type type) -> std::optional<unsigned> {
+      if (type.isF16() || type.isBF16())
+        return 16;
+      if (type.isF32() && allowTF32)
+        return 8;
+      if (type.isInteger(8) || llvm::isa<Float8E5M2Type>(type) ||
+          llvm::isa<Float8E4M3FNType>(type))
+        return 32;
+      return std::nullopt;
+    };
+    auto aInstructionK = instructionKForType(aTensorTy.getElementType());
+    auto bInstructionK = instructionKForType(bTensorTy.getElementType());
+    bool canSelectInstructionK = mmaEncoding.isHopper() && aInstructionK &&
+                                 bInstructionK &&
+                                 *aInstructionK == *bInstructionK;
+    if (canSelectInstructionK) {
+      instrMNK[2] = *aInstructionK;
+    } else if (op->hasAttr(kTleWgmmaAccumulatorChainCAttr)) {
+      op->emitError(
+          "cannot select a Hopper shared/shared WGMMA instruction shape "
+          "for this accumulator chain");
+      return failure();
+    }
+  }
+#endif
   auto accSize = 2 * (instrMNK[1] / 4);
   unsigned M = 4 * instrMNK[0];
   unsigned N = instrMNK[1];

--- a/third_party/tle/test/GPU/test_tle_cross_dtype_wgmma_accumulator.mlir
+++ b/third_party/tle/test/GPU/test_tle_cross_dtype_wgmma_accumulator.mlir
@@ -1,0 +1,47 @@
+// Copyright 2025- FlagOS Contributors
+//
+// RUN: triton-opt %s --allocate-shared-memory-nv='compute-capability=90 ptx-version=81' --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=81' --convert-nv-gpu-to-llvm | FileCheck %s
+
+#mma_fp8 = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 64, 32]}>
+#mma_bf16 = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 64, 16]}>
+#dot_bf16 = #ttg.dot_op<{opIdx = 0, parent = #mma_bf16, kWidth = 2}>
+#shared_a_bf16 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = false, elementBitWidth = 16}>
+#shared_b_bf16 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.target" = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // The async C value retains the preceding FP8/K32 MMA encoding. The current
+  // BF16 register-A operand selects K16, while both encodings have identical C
+  // register ownership.
+  // CHECK-LABEL: @fp8_k32_acc_to_bf16_k16_reg_a
+  // CHECK: wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16
+  // CHECK-NOT: wgmma.mma_async.sync.aligned.m64n64k32.f32.bf16.bf16
+  tt.func @fp8_k32_acc_to_bf16_k16_reg_a(
+      %a: tensor<64x64xbf16, #dot_bf16>,
+      %b: !ttg.memdesc<64x64xbf16, #shared_b_bf16, #smem>,
+      %acc: tensor<64x64xf32, #mma_fp8>) {
+    %res = ttng.warp_group_dot %a, %b, %acc {
+      inputPrecision = 0 : i32,
+      isAsync = true,
+      tle.wgmma_accumulator_chain_c
+    } : tensor<64x64xbf16, #dot_bf16> * !ttg.memdesc<64x64xbf16, #shared_b_bf16, #smem> -> tensor<64x64xf32, #mma_fp8>
+    tt.return
+  }
+
+  // Shared-A has no BF16 dot-parent encoding, and the production scheduling
+  // pipeline may no longer carry the chain marker by this point. Current BF16
+  // operands still select K16 while preserving FP8 C's M/N ownership.
+  // CHECK-LABEL: @fp8_k32_acc_to_bf16_k16_shared_shared
+  // CHECK: wgmma.mma_async.sync.aligned.m64n64k16.f32.bf16.bf16
+  // CHECK-NOT: wgmma.mma_async.sync.aligned.m64n64k32.f32.bf16.bf16
+  tt.func @fp8_k32_acc_to_bf16_k16_shared_shared(
+      %a: !ttg.memdesc<64x64xbf16, #shared_a_bf16, #smem>,
+      %b: !ttg.memdesc<64x64xbf16, #shared_b_bf16, #smem>,
+      %acc: tensor<64x64xf32, #mma_fp8>) {
+    %res = ttng.warp_group_dot %a, %b, %acc {
+      inputPrecision = 0 : i32,
+      isAsync = true
+    } : !ttg.memdesc<64x64xbf16, #shared_a_bf16, #smem> * !ttg.memdesc<64x64xbf16, #shared_b_bf16, #smem> -> tensor<64x64xf32, #mma_fp8>
+    tt.return
+  }
+}

--- a/third_party/tle/test/GPU/test_tle_cross_dtype_wgmma_accumulator_invalid.mlir
+++ b/third_party/tle/test/GPU/test_tle_cross_dtype_wgmma_accumulator_invalid.mlir
@@ -1,0 +1,24 @@
+// Copyright 2025- FlagOS Contributors
+//
+// RUN: not triton-opt %s --allocate-shared-memory-nv='compute-capability=90 ptx-version=81' --convert-triton-gpu-to-llvm='compute-capability=90 ptx-version=81' 2>&1 | FileCheck %s
+
+#mma_fp8 = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 64, 32]}>
+#mma_bf16_bad_n = #ttg.nvidia_mma<{versionMajor = 3, versionMinor = 0, warpsPerCTA = [4, 1], instrShape = [16, 128, 16]}>
+#dot_bf16_bad_n = #ttg.dot_op<{opIdx = 0, parent = #mma_bf16_bad_n, kWidth = 2}>
+#shared_bf16 = #ttg.nvmma_shared<{swizzlingByteWidth = 128, transposed = true, elementBitWidth = 16}>
+#smem = #ttg.shared_memory
+
+module attributes {"ttg.num-ctas" = 1 : i32, "ttg.num-warps" = 4 : i32, "ttg.target" = "cuda:90", "ttg.threads-per-warp" = 32 : i32} {
+  // CHECK: error: cannot reuse an async WGMMA accumulator across incompatible physical C layouts
+  tt.func @reject_incompatible_accumulator_n_layout(
+      %a: tensor<64x64xbf16, #dot_bf16_bad_n>,
+      %b: !ttg.memdesc<64x64xbf16, #shared_bf16, #smem>,
+      %acc: tensor<64x64xf32, #mma_fp8>) {
+    %res = ttng.warp_group_dot %a, %b, %acc {
+      inputPrecision = 0 : i32,
+      isAsync = true,
+      tle.wgmma_accumulator_chain_c
+    } : tensor<64x64xbf16, #dot_bf16_bad_n> * !ttg.memdesc<64x64xbf16, #shared_bf16, #smem> -> tensor<64x64xf32, #mma_fp8>
+    tt.return
+  }
+}


### PR DESCRIPTION
## Problem

A TLE Hopper WGMMA chain can reuse the same FP32 accumulator for FP8/K32 and BF16/K16 operations. The accumulator retains its previous encoding, so selecting the instruction shape entirely from that encoding can incorrectly emit BF16/K32 and fail during PTX lowering.

The failure was reproduced on H800 with the PR parent compiler (`fd3ea294d`) using the unmodified downstream MLA operator at B1/L640/HQ128:

```text
NVGPUToLLVMPass.cpp:496:
Assertion `supported && "WGMMA type or shape is not supported"' failed.
RuntimeError: PassManager::run failed
```

The BF16 WGMMA consumes the preceding FP8 accumulator with `instrShape = [16, 64, 32]`; the old lowering incorrectly selects K32 instead of the BF16-required K16. With this fix (`2ace55eca`), the same operator source compiles and passes output/LSE accuracy checks using a separate fresh compilation cache.

## Changes

- Select instruction K from the current operand types for both register-A and shared-A operations, while preserving the accumulator's M/N and layout.
- Reuse the existing operand-type checks, including TF32 precision validation and support for mixed E4M3/E5M2 FP8 operands.
- Validate register-A layout compatibility independently of the chain marker, which FenceInsertion can remove. Incompatible layouts now produce a diagnostic even when the marker is absent.
- Keep the lowering changes scoped to TLE and simplify instruction-shape construction.

## Validation

On H800:

- Build and pre-commit checks passed.
- 14 MLIR scenarios passed, covering cross-dtype reuse, supported operand types, and rejection of incompatible layouts/types, including cases without the chain marker.
- 6 routing tests and 3 downstream operator tests passed.
- All 24 downstream shapes passed accuracy and replay determinism checks against [CUDA FP8 FlashMLA](https://github.com/meituan-longcat/FlashMLA/tree/feature/ckv_fp8_per_token). Maximum output relative L2 error was 0.007768; maximum LSE absolute error was 2.862e-6.

Before/after suite comparisons retained the same pre-existing failures: 65/72 TLE tests and 10/11 selected NVIDIA lowering tests passed. Both cross-dtype MLIR files passed.

A separate non-TLE build and Compute Sanitizer were not run.
