### PR TITLE
[BUILD] Publish release packages to FlagOS Nexus via the shared build-infra workflow

### DIFF
--- a/.github/workflows/upload-nexus.yml
+++ b/.github/workflows/upload-nexus.yml
@@ -1,0 +1,27 @@
+# Publish the deb/rpm artifacts of a release tag to the FlagOS Nexus
+# repositories through the shared workflow in flagos-ai/build-infra.
+#
+# The shared workflow waits for build-deb.yml (required) and build-rpm.yml
+# (optional) of the same commit, downloads their artifacts, uploads them, and
+# fails loudly if nothing could be uploaded. Pre-release tags (rc/alpha/beta/
+# dev) are skipped by its guard job; workflow_dispatch always publishes and
+# accepts an explicit build run id.
+name: Upload to Nexus Repository
+
+on:
+  push:
+    tags:
+      - '[0-9]*'
+      - 'v[0-9]*'
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: 'Build workflow run ID (optional, uses latest successful run if blank)'
+        required: false
+
+jobs:
+  upload:
+    uses: flagos-ai/build-infra/.github/workflows/upload-nexus.yml@main
+    with:
+      run_id: ${{ github.event.inputs.run_id }}
+    secrets: inherit


### PR DESCRIPTION
## Why

`build-deb.yml` / `build-rpm.yml` (#607 / #794 / #796) produce the FlagTree deb/rpm, but nothing publishes them; FlagOS Nexus holds no FlagTree package.

## What

Adds `.github/workflows/upload-nexus.yml`, a thin caller of the shared [`flagos-ai/build-infra/.github/workflows/upload-nexus.yml`](https://github.com/flagos-ai/build-infra/blob/main/.github/workflows/upload-nexus.yml) — identical to the one libtriton_jit uses. Tag patterns match the build workflows (`[0-9]*`, `v[0-9]*`). The shared workflow:

- skips pre-release tags (`rc`/`a`/`b`/`dev`) on `push`, always publishes on `workflow_dispatch`
- waits for `build-deb.yml` (required) and `build-rpm.yml` (optional) of the same commit, downloads their artifacts
- uploads deb → `flagos-apt-hosted`, rpm → `flagos-yum-hosted` using the org-level `NEXUS_TOKEN`
- fails the job if packages were found but none uploaded

Note: because release tags are pushed with `GITHUB_TOKEN` from the delivery workflows, neither the build workflows nor this one fire on tags today (#1062). Until that is fixed, publishing is: dispatch `build-deb`/`build-rpm` on the tag, then dispatch this workflow with the build `run_id`.

Part of FEP-0019 Wave 1 (flagos-ai/community#59).