### PR TITLE
[CD] Dispatch build-deb/build-rpm after pushing a release tag

### DIFF
--- a/.github/workflows/aipu3.3-delivery.yml
+++ b/.github/workflows/aipu3.3-delivery.yml
@@ -22,6 +22,7 @@ name: CD-AIPU3.3
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -168,6 +169,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/amd3.6-delivery.yml
+++ b/.github/workflows/amd3.6-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Amd3.6
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -168,6 +169,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/ascend3.2-delivery.yml
+++ b/.github/workflows/ascend3.2-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Ascend3.2
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -167,6 +168,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/ascend3.5-delivery.yml
+++ b/.github/workflows/ascend3.5-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Ascend3.5
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -167,6 +168,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/enflame3.5-gcu400-delivery.yml
+++ b/.github/workflows/enflame3.5-gcu400-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Enflame3.5-GCU400
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -166,6 +167,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/enflame3.6-gcu400-delivery.yml
+++ b/.github/workflows/enflame3.6-gcu400-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Enflame3.6-GCU400
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -166,6 +167,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/hcu3.1-delivery.yml
+++ b/.github/workflows/hcu3.1-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Hcu3.1
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -167,6 +168,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/hcu3.6-delivery.yml
+++ b/.github/workflows/hcu3.6-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Hcu3.6
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -166,6 +167,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/iluvatar3.1-delivery.yml
+++ b/.github/workflows/iluvatar3.1-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Iluvatar3.1
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -167,6 +168,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/iluvatar3.6-delivery.yml
+++ b/.github/workflows/iluvatar3.6-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Iluvatar3.6
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -166,6 +167,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/metax3.0-delivery.yml
+++ b/.github/workflows/metax3.0-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Metax3.0
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -168,6 +169,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/metax3.6-delivery.yml
+++ b/.github/workflows/metax3.6-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Metax3.6
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -166,6 +167,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/mthreads3.1-delivery.yml
+++ b/.github/workflows/mthreads3.1-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Mthreads3.1
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -167,6 +168,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/mthreads3.2-delivery.yml
+++ b/.github/workflows/mthreads3.2-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Mthreads3.2
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -167,6 +168,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/mthreads3.6-delivery.yml
+++ b/.github/workflows/mthreads3.6-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Mthreads3.6
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -166,6 +167,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/nvidia3.3-delivery.yml
+++ b/.github/workflows/nvidia3.3-delivery.yml
@@ -22,6 +22,7 @@ name: CD-NV3.3
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -169,6 +170,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/nvidia3.5-delivery.yml
+++ b/.github/workflows/nvidia3.5-delivery.yml
@@ -22,6 +22,7 @@ name: CD-NV3.6
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -172,6 +173,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/nvidia3.6-delivery.yml
+++ b/.github/workflows/nvidia3.6-delivery.yml
@@ -22,6 +22,7 @@ name: CD-NV3.6
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -172,6 +173,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/ppu3.6-delivery.yml
+++ b/.github/workflows/ppu3.6-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Ppu3.6
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -166,6 +167,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/sunrise3.4-delivery.yml
+++ b/.github/workflows/sunrise3.4-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Sunrise3.4
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -169,6 +170,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/thrive3.6-delivery.yml
+++ b/.github/workflows/thrive3.6-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Thrive3.6
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -166,6 +167,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/tileir3.6-delivery.yml
+++ b/.github/workflows/tileir3.6-delivery.yml
@@ -22,6 +22,7 @@ name: CD-TileIR3.6
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -170,6 +171,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/tsingmicro3.3-delivery.yml
+++ b/.github/workflows/tsingmicro3.3-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Tsingmicro3.3
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -174,6 +175,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/xpu3.0-delivery.yml
+++ b/.github/workflows/xpu3.0-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Xpu3.0
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -167,6 +168,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash

--- a/.github/workflows/xpu3.6-delivery.yml
+++ b/.github/workflows/xpu3.6-delivery.yml
@@ -22,6 +22,7 @@ name: CD-Xpu3.6
 
 permissions:
   contents: write
+  actions: write
 
 on:
   workflow_dispatch:
@@ -166,6 +167,27 @@ jobs:
             echo "git push failed after $MAX_RETRY attempts"
             exit 1
           fi
+
+      - name: Trigger packaging workflows for the release tag
+        # Tags pushed with GITHUB_TOKEN never fire `push` events (GitHub blocks
+        # recursive workflow runs), so build-deb/build-rpm would otherwise stay
+        # idle for every release tag (#1062). workflow_dispatch is the documented
+        # exception, so dispatch them explicitly. Backend-variant tags
+        # (<version>+<backend>) are not packaged and are skipped here as well.
+        if: ${{ !contains(env.FLAGTREE_WHEEL_VERSION, '+') }}
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${FLAGTREE_WHEEL_VERSION}"
+          for wf in build-deb.yml build-rpm.yml; do
+            echo "Dispatching ${wf} on ${TAG}"
+            curl -fsS -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              "https://api.github.com/repos/${{ github.repository }}/actions/workflows/${wf}/dispatches" \
+              -d "{\"ref\":\"${TAG}\"}"
+          done
 
       - name: FlagTree upload whl
         shell: bash


### PR DESCRIPTION
## Why

Release tags are created inside the `*-delivery.yml` workflows and pushed with the job's `GITHUB_TOKEN`. GitHub deliberately fires no `push` event for refs created with that token (to prevent recursive runs), so `build-deb.yml` / `build-rpm.yml` — which trigger on `[0-9]*` / `v[0-9]*` tags — have never run for a release tag: `0.6.1`, `0.6.2a1` and every other tag show zero packaging runs. Details and verification in #1062. The same applies to the Nexus upload caller from #1063: it triggers on tag push, so it would never fire for delivery-created tags either.

## What

`workflow_dispatch` is the documented exception to that rule, so each delivery workflow now dispatches the packaging chain on the tag it just pushed:

- one new step right after **FlagTree push tag**, identical in all 25 `*-delivery.yml` files (same anchor block in every file)
- dispatches `build-deb.yml`, `build-rpm.yml` and `upload-nexus.yml`; the upload is skipped (not fatal) while #1063 hasn't landed on the tagged commit
- plain `curl` against `POST /repos/{repo}/actions/workflows/{wf}/dispatches` — no dependency on `gh` being installed on the self-hosted runners
- **only stable release tags are dispatched**: because dispatch bypasses the upload workflow's own tag guard, the step applies the same stable-tag allowlist regex as that guard (`^v?[0-9]+(\.[0-9]+){0,3}(\.post[0-9]+)?$`). This skips backend-variant tags (`<version>+<backend>`) and also plain pre-release tags (`0.6.0rc1`), which a bare `+`-check would let through
- `permissions: actions: write` added next to the existing `contents: write`, which the dispatch call requires

The packaging workflows themselves are unchanged; on a dispatched run they build the tag's commit exactly as a tag push would have. On the build-infra side, flagos-ai/build-infra#912 makes the dispatched upload wait for this exact commit's builds instead of falling back to the latest successful run.

## Alternatives considered

Pushing the tag with a PAT / GitHub App token would make the normal `push` trigger work but needs a new secret with broader permissions; folding packaging into the delivery workflows via `workflow_call` is cleaner long-term but a much larger change. This is the minimal fix; happy to follow up with either if preferred.

Fixes #1062. Related: #1063 (publishing the built packages to FlagOS Nexus), flagos-ai/build-infra#912 (build-wait on dispatched uploads).
