### PR TITLE
[TLE][Ascend][XCS] Add new gather(indirect addressing) and sort ops

### DIFF
--- a/.github/workflows/ascend3.5-910b-cann9.1.0-test.yml
+++ b/.github/workflows/ascend3.5-910b-cann9.1.0-test.yml
@@ -90,3 +90,7 @@ jobs:
           PATH=/usr/local/Ascend/cann-9.1.0-shmem/bin:$PATH torchrun --nproc_per_node=2 09-ascend-allgather-gemm.py
           PATH=/usr/local/Ascend/cann-9.1.0-shmem/bin:$PATH torchrun --nproc_per_node=2 10-tle-d2d-barrier.py
           popd
+          ## flagtree tle custom-op tutorial
+          pushd python/tutorials/tle/custom
+          python3 test_custom_ops.py
+          popd

--- a/python/triton/experimental/tle/language/dsa/ascend/__init__.py
+++ b/python/triton/experimental/tle/language/dsa/ascend/__init__.py
@@ -1,7 +1,8 @@
 # Copyright 2026- Xcoresigma Technology Co., Ltd
 
 from .core import (UB, L1, L0A, L0B, L0C, PIPE, sub_vec_id, sub_vec_num, sync_block_set, sync_block_wait,
-                   sync_block_all, compile_hint, multibuffer)
+                   sync_block_all, compile_hint, raw, multibuffer)
+from . import custom_ops
 
 __all__ = [
     "UB",
@@ -16,5 +17,6 @@ __all__ = [
     "sync_block_wait",
     "sync_block_all",
     "compile_hint",
+    "raw",
     "multibuffer",
 ]

--- a/python/triton/experimental/tle/language/dsa/ascend/core.py
+++ b/python/triton/experimental/tle/language/dsa/ascend/core.py
@@ -2,7 +2,7 @@
 
 from triton.language.extra.cann.extension.core import ascend_address_space, sub_vec_id, sub_vec_num, sync_block_set, sync_block_wait, sync_block_all
 import triton.language.extra.cann.extension as ascend_langugage_cann_extension
-from triton.language.extra.cann.extension import compile_hint, multibuffer
+from triton.language.extra.cann.extension import compile_hint, custom as raw, multibuffer
 
 UB = ascend_address_space.UB
 L1 = ascend_address_space.L1
@@ -16,5 +16,6 @@ sync_block_set = sync_block_set
 sync_block_wait = sync_block_wait
 sync_block_all = sync_block_all
 compile_hint = compile_hint
+raw = raw
 multibuffer = multibuffer
 PIPE = ascend_langugage_cann_extension.PIPE

--- a/python/triton/experimental/tle/language/dsa/ascend/custom_ops/CUSTOM_OP_USAGE.md
+++ b/python/triton/experimental/tle/language/dsa/ascend/custom_ops/CUSTOM_OP_USAGE.md
@@ -1,0 +1,227 @@
+# Ascend Custom Ops 使用说明
+
+## 目录结构
+
+```text
+custom_ops/
+├── CUSTOM_OP_USAGE.md              # 本文档
+├── __init__.py                     # 对外导出注册算子和公共常量
+├── common.py                       # 存放结构体变量和公共函数
+├── registry.py                     # Python custom op 注册表
+├── build_custom_ops.sh             # 手动重新编译统一 bitcode
+├── custom_ops.bc                   # 所有注册算子共用的 bitcode，编译后生成
+├── mem_ops/
+│   ├── gather_gm_to_l1.cpp         # GM → L1/CBUF 按索引行 gather
+│   └── gather_gm_to_ub.cpp         # GM → UB 按索引行 gather
+└── sort_ops/
+    ├── sort_1d_pack.cpp            # sort_1d_pack ABI 与路径分发
+    ├── sort_common.h                # 共享 vmrgsort4 / proposal inline 工具
+    ├── sort_base.h               # 通用排序路径
+    ├── sort_s4096_k129_512.h     # 4096 segment、128 < K <= 512 的 4×1024 small-K 排序路径
+    ├── sort_s4096_k1_128_k2048.h # 4096 segment、K <= 128 或 K == 2048 的分层排序路径
+    ├── merge_pack_sort.cpp         # proposal 归并与解包
+    └── unpack_sort.cpp             # proposal 拆包为 value/index
+```
+
+`registry.py` 中的所有算子均引用同一个 `custom_ops.bc`。每个算子的 `.cpp` 分别用对应 ccec 架构（`dav-c220-cube` 或 `dav-c220-vec`）编译为自己的 `.bc`，再与 Template bitcode 一起 `llvm-link` 成 `custom_ops.bc`。
+
+## 调用约定
+
+在 Triton kernel 中通过 `tle.dsa.ascend.raw` 调用：
+
+```python
+result = tle.dsa.ascend.raw(
+    "op_name",
+    input0,
+    input1,
+    out=result_buffer,
+)
+```
+
+多输出写成：
+
+```python
+output0, output1 = tle.dsa.ascend.raw(
+    "op_name",
+    input0,
+    out=[output0, output1],
+)
+```
+
+普通位置参数对应 custom op inputs，`out=` 对应 outputs。纯输出 buffer 只应在 `out=` 中出现一次，不要同时作为普通参数重复传入。
+
+## 已注册算子
+
+| 算子 | Core / Pipe | 功能 | `out=` 含义 | C++ 实现 |
+| --- | --- | --- | --- | --- |
+| `gather_gm_to_l1` | CUBE / MTE2 | 按索引将 GM 连续张量中的 half/bf16 数据行收集到 L1/CBUF，并完成 ND2NZ 搬运 | L1/CBUF half/bf16 目标张量，对应 C++ `dst` | `mem_ops/gather_gm_to_l1.cpp` |
+| `gather_gm_to_ub` | VECTOR / MTE2 | 按索引将 GM 连续张量中的 half/bf16 数据行收集到 UB | UB half/bf16 目标张量，对应 C++ `dst` | `mem_ops/gather_gm_to_ub.cpp` |
+| `sort_1d_pack` | VECTOR / V | 对一维 float 数据排序，输出前 `TOPK` 个紧凑 proposal | UB float proposal 输出，对应 C++ `dst_proposals` | `sort_ops/sort_1d_pack.cpp:10-18` |
+| `merge_exhaust_sort4` | VECTOR / V | 对最多四路有序 proposal 执行一次 exhaustion merge | `[dst_proposals, consumed_out]` | `sort_ops/merge_pack_sort.cpp:56-63` |
+| `unpack_sort` | VECTOR / V | 将 `[value, encoded_index]` proposal 拆分成 value 和 index | `[dst_value, dst_index]` | `sort_ops/unpack_sort.cpp:20-24` |
+
+## 算子使用方法
+
+### `gather_gm_to_l1`
+
+```python
+tile_k = tle.dsa.ascend.raw(
+    "gather_gm_to_l1",
+    src,
+    src_index,
+    tile_size,
+    D,
+    out=tile_k,
+)
+```
+
+- `src`：GM 二维 half/bf16 源张量，行连续；
+- `src_index`：GM 二维 int32 索引张量（形状 `(N, 1)`、stride `(1, 1)`），输出第 i 行的数据取自源张量第 `index[i]` 行（0-based 行号）；索引起始偏移通过 block ptr 的 `offsets` 表达；
+- `tile_size`：本次收集的行数；
+- `D`：每行元素数；
+- `out`：四维 L1/CBUF half/bf16 输出。
+
+相邻索引（`index[i + 1] == index[i] + 1`）会合并为一次两行搬运。
+
+> **重要**：调用本算子的 kernel 必须传编译选项 `disable_auto_cv_work_space_manage=True`。CANN 9.1.0（bishengir 1.2.0 正式版）重构了 `InsertLoadStoreForMixCV`，重构版对 custom op 的 memscope / coreType 推断仍有 bug：PIPE_MTE2 custom op 的 out 会被规划到 GM workspace（并误插 cbuf→cbuf load），与本算子 `__cbuf__` 的 C++ ABI 冲突。
+>
+> **TODO**：`disable_auto_cv_work_space_manage=True` 只是临时规避（per-kernel 关闭 mix-CV workspace 管理，会连带关闭 multi-buffer / CV 流水线）。等 bishengir 修复重构版 `InsertLoadStoreForMixCV` 对 custom op 的推断 bug，或后端编译选项加上 `-enable-legacy-insert-load-store-for-mix-cv`（整个 pass 回退到重构前的老版本）后，去掉该 kwarg。
+
+完整示例见 `python/tutorials/tle/custom/test_custom_ops.py`（`test_gather_gm_to_l1`）。
+
+### `gather_gm_to_ub`
+
+```python
+tile_v = tle.dsa.ascend.raw(
+    "gather_gm_to_ub",
+    src,
+    src_index,
+    tile_size,
+    D,
+    out=tile_v,
+)
+```
+
+参数含义与 `gather_gm_to_l1` 相同，区别是结果写入二维 UB half/bf16 张量。输出第一维 stride 不得小于 `D`。
+
+> **重要**：与 `gather_gm_to_l1` 相同，调用本算子的 kernel 必须传 `disable_auto_cv_work_space_manage=True`（PIPE_MTE2 + `__ubuf__` ABI，原因同上）。
+>
+> **TODO**：去掉条件同 `gather_gm_to_l1`——等 `InsertLoadStoreForMixCV` 重构 bug 修复，或后端加上 `-enable-legacy-insert-load-store-for-mix-cv` 后，该 kwarg 可去掉。
+
+完整示例见 `python/tutorials/tle/custom/test_custom_ops.py`（`test_gather_gm_to_ub`）。
+
+### `sort_1d_pack`
+
+```python
+proposals = tle.dsa.ascend.raw(
+    "sort_1d_pack",
+    src,
+    tmp_buf,
+    descending,
+    TOPK,
+    index_offset,
+    sort_impl,
+    out=proposals,
+)
+```
+
+proposal 使用两个 float 槽位紧凑存储：
+
+```text
+[value0, encoded_index0, value1, encoded_index1, ...]
+```
+
+`out` 至少需要容纳 `2 * TOPK` 个 float。`tmp_buf` 是 UB workspace，大小应与所选排序路径匹配。
+
+#### 排序路径
+
+| 路径 | 值 | 适用情况 | 实现 |
+| --- | ---: | --- | --- |
+| `SORT_IMPL_BASE` | 0 | 通用 fallback；非 4096 segment，或不适合特化路径的场景 | `sort_base.h` |
+| `SORT_IMPL_S4096_K129_512` | 1 | 固定 4096 输入、较小 K；当前示例用于 `128 < K <= 512` | `sort_s4096_k129_512.h` |
+| `SORT_IMPL_S4096_K1_128_K2048` | 2 | 固定 4096 输入；很小 K 可 early-stop，K == 2048 使用固定树归并 | `sort_s4096_k1_128_k2048.h` |
+
+三条路径由调用方通过 `sort_impl` 选择，C++ 只执行 switch 分发；未知值回退到 BASE，见 `sort_ops/sort_1d_pack.cpp:19-36`。
+
+推荐的选择策略（`seg_len` 为每段输入长度，`K` 为本段需要保留的 proposal 数，即 `min(TOPK, seg_len)`）为：
+
+```text
+seg_len == 4096 且 0 < K <= 128  → S4096_K1_128_K2048
+seg_len == 4096 且 128 < K <= 512 → S4096_K129_512
+seg_len == 4096 且 K == 2048      → S4096_K1_128_K2048
+其他情况                           → BASE
+```
+
+单算子正确性测试见 `python/tutorials/tle/custom/test_custom_ops.py`（`test_sort_1d_pack`，覆盖三条路径）。
+
+三条路径简述：
+
+- **BASE**：生成 index，通过 `vbitsort` 形成初始 proposal，再用 `vmrgsort4` 做通用多级归并；
+- **S4096_K129_512**：把 4096 个输入拆成四个 1024 元素 chunk，各自排序后进行四路 exhaustion merge；
+- **S4096_K1_128_K2048**：按 `32 → 128 → 512 → 2048` proposal 的层级归并，小 K 可在中间层提前停止，K == 2048 走固定树。
+
+### `merge_exhaust_sort4`
+
+```python
+out_buf, consumed = tle.dsa.ascend.raw(
+    "merge_exhaust_sort4",
+    src_proposals,
+    ways,
+    off0, off1, off2, off3,
+    len0, len1, len2, len3,
+    out=[out_buf, consumed],
+)
+```
+
+- `off0..off3`：每一路的起始偏移，单位为 proposal；
+- `len0..len3`：每一路的 proposal 数量，`0` 表示该路无效；
+- `out[0]`：归并后可安全确定的有序 proposal 前缀；
+- `out[1]`：至少四个 int32，记录原始四路本次消耗的 proposal 数量。
+
+该算子只执行一次归并。多轮加载、cursor 推进和完整归并由调用方负责。
+
+示例见 `python/tutorials/tle/custom/test_custom_ops.py`（`test_merge_exhaust_sort4`）。
+
+### `unpack_sort`
+
+```python
+values, indices = tle.dsa.ascend.raw(
+    "unpack_sort",
+    src_proposals,
+    topk,
+    out=[values, indices],
+)
+```
+
+输出顺序固定：
+
+```text
+out[0] = UB float dst_value
+out[1] = UB int32 dst_index
+```
+
+`src_proposals` 的有效 view 应覆盖 `2 * topk` 个 float 槽位。示例见 `python/tutorials/tle/custom/test_custom_ops.py`（`test_unpack_sort`）。
+
+
+## 编译方法
+
+### 默认自动编译
+
+正常构建工程时，CMake 会直接调用 `ccec` / `llvm-link` 生成或更新 `custom_ops.bc`。规则位于 `third_party/tle/dsa/dialect/lib/CMakeLists.txt`：每个算子的 `.cpp` 按各自 aicore 架构编译为独立 `.bc`（中间产物在构建目录 `ascend_custom_ops/` 下），4 个 Template 源码编译后一起 `llvm-link` 成 `custom_ops.bc`。
+
+```bash
+rm -rf build
+FLAGTREE_BACKEND=ascend MAX_JOBS=32 \
+  python3 -m pip install -e . --no-build-isolation -v
+```
+
+当 `custom_ops.bc` 不存在，或某个算子声明的 C++ 源码依赖发生变化时，CMake 只重新编译受影响的算子并重新 link。
+
+### 修改 C++ 实现后手动编译
+
+如果只修改了 custom op 的 C++ 实现，并且 Python 注册和 C++ ABI 没有变化，可以直接运行：
+
+```bash
+cd /root/xcs_flagtree/python/triton/experimental/tle/language/dsa/ascend/custom_ops
+./build_custom_ops.sh
+```

--- a/python/triton/experimental/tle/language/dsa/ascend/custom_ops/__init__.py
+++ b/python/triton/experimental/tle/language/dsa/ascend/custom_ops/__init__.py
@@ -1,0 +1,27 @@
+# Copyright 2026- Xcoresigma Technology Co., Ltd
+
+# 枚举变量
+from .common import (
+    SORT_IMPL_BASE,
+    SORT_IMPL_S4096_K129_512,
+    SORT_IMPL_S4096_K1_128_K2048,
+)
+# 面向用户的 custom op
+from .registry import (
+    gather_gm_to_l1,
+    gather_gm_to_ub,
+    sort_1d_pack,
+    merge_exhaust_sort4,
+    unpack_sort,
+)
+
+__all__ = [
+    "SORT_IMPL_BASE",
+    "SORT_IMPL_S4096_K129_512",
+    "SORT_IMPL_S4096_K1_128_K2048",
+    "gather_gm_to_l1",
+    "gather_gm_to_ub",
+    "sort_1d_pack",
+    "merge_exhaust_sort4",
+    "unpack_sort",
+]

--- a/python/triton/experimental/tle/language/dsa/ascend/custom_ops/build_custom_ops.sh
+++ b/python/triton/experimental/tle/language/dsa/ascend/custom_ops/build_custom_ops.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Copyright 2026- Xcoresigma Technology Co., Ltd
+# Manual rebuild of custom_ops.bc — the normal build drives ccec/llvm-link
+# directly from third_party/tle/dsa/dialect/lib/CMakeLists.txt instead.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+CUSTOM_OPS_BC="${SCRIPT_DIR}/custom_ops.bc"
+TEMPLATE_ROOT="${SCRIPT_DIR}/../../../../../../../../third_party/ascend/AscendNPU-IR/bishengir/lib/Template"
+TEMPLATE_INCLUDE="${TEMPLATE_ROOT}/include"
+TEMPLATE_LIB="${TEMPLATE_ROOT}/lib"
+TEMPLATE_BC=(
+  "${SCRIPT_DIR}/template_arange.bc"
+  "${SCRIPT_DIR}/template_eltwise1d.bc"
+  "${SCRIPT_DIR}/template_sort1d.bc"
+  "${SCRIPT_DIR}/template_copy1d.bc"
+)
+
+CCEC="${CCEC:-$(command -v ccec || true)}"
+if [[ -z "${CCEC}" ]]; then
+  echo "error: ccec not found; source the CANN environment first" >&2
+  exit 1
+fi
+CCEC="$(readlink -f "${CCEC}")"
+
+CCEC_BIN_DIR="$(dirname -- "${CCEC}")"
+LLVM_LINK="${LLVM_LINK:-${CCEC_BIN_DIR}/llvm-link}"
+if [[ ! -x "${LLVM_LINK}" ]]; then
+  echo "error: CANN llvm-link not found: ${LLVM_LINK}" >&2
+  exit 1
+fi
+
+# Each custom op is implemented in its own .cpp and compiled into its own
+# bitcode: "<src>::<arch>" — arch is the ccec aicore target for that op.
+CUSTOM_OPS=(
+  "mem_ops/gather_gm_to_l1.cpp:dav-c220-cube"
+  "mem_ops/gather_gm_to_ub.cpp:dav-c220-vec"
+  "sort_ops/sort_1d_pack.cpp:dav-c220-vec"
+  "sort_ops/merge_pack_sort.cpp:dav-c220-vec"
+  "sort_ops/unpack_sort.cpp:dav-c220-vec"
+)
+
+if [[ ! -d "${TEMPLATE_INCLUDE}" ]]; then
+  echo "error: Ascend Template include directory not found: ${TEMPLATE_INCLUDE}" >&2
+  exit 1
+fi
+
+OP_BC=()
+for entry in "${CUSTOM_OPS[@]}"; do
+  src="${entry%%:*}"
+  arch="${entry##*:}"
+  if [[ ! -f "${SCRIPT_DIR}/${src}" ]]; then
+    echo "error: custom-op source not found: ${SCRIPT_DIR}/${src}" >&2
+    exit 1
+  fi
+
+  CCEC_COMMON_ARGS=( -O2 -x cce --cce-auto-sync=off --cce-aicore-only
+    --cce-generic-addrspace=off -mllvm -disable-llvm-optzns
+    --cce-aicore-arch="${arch}" --cce-enable-print
+    --cce-enable-sanitizer -std=c++17 -I "${TEMPLATE_INCLUDE}" )
+
+  bc="${SCRIPT_DIR}/${src%.cpp}.bc"
+  mix_bc="${SCRIPT_DIR}/${src%.cpp}.mix.bc"
+  OP_BC+=("${bc}" "${mix_bc}")
+
+  echo "== ccec ${src} (${arch})"
+  "${CCEC}" "${CCEC_COMMON_ARGS[@]}" \
+    "${SCRIPT_DIR}/${src}" -emit-llvm -c -o "${bc}"
+
+  echo "== ccec ${src} (${arch}, mix)"
+  "${CCEC}" "${CCEC_COMMON_ARGS[@]}" -cce-enable-mix -mllvm -enable-mix=true \
+    "${SCRIPT_DIR}/${src}" -emit-llvm -c -o "${mix_bc}"
+done
+
+TEMPLATE_SOURCES=(
+  "${TEMPLATE_LIB}/Vector/Arange/Arange1D.cpp"
+  "${TEMPLATE_LIB}/Vector/Elementwise/EltWise1D.cpp"
+  "${TEMPLATE_LIB}/Vector/Sort/Sort1D.cpp"
+  "${TEMPLATE_LIB}/DMA/Ubuf/Copy1D.cpp"
+)
+TEMPLATE_MIX_BC=()
+for i in "${!TEMPLATE_SOURCES[@]}"; do
+  echo "== ccec ${TEMPLATE_SOURCES[$i]}"
+  "${CCEC}" -O2 -x cce --cce-auto-sync=off --cce-aicore-only \
+    --cce-generic-addrspace=off -mllvm -disable-llvm-optzns \
+    --cce-aicore-arch=dav-c220-vec --cce-enable-print \
+    --cce-enable-sanitizer -std=c++17 -I "${TEMPLATE_INCLUDE}" \
+    "${TEMPLATE_SOURCES[$i]}" -emit-llvm -c -o "${TEMPLATE_BC[$i]}"
+  mix_bc="${TEMPLATE_BC[$i]%.bc}.mix.bc"
+  echo "== ccec ${TEMPLATE_SOURCES[$i]} (mix)"
+  "${CCEC}" -O2 -x cce --cce-auto-sync=off --cce-aicore-only \
+    --cce-generic-addrspace=off -mllvm -disable-llvm-optzns \
+    --cce-aicore-arch=dav-c220-vec --cce-enable-print \
+    --cce-enable-sanitizer -std=c++17 -I "${TEMPLATE_INCLUDE}" \
+    -cce-enable-mix -mllvm -enable-mix=true \
+    "${TEMPLATE_SOURCES[$i]}" -emit-llvm -c -o "${mix_bc}"
+  TEMPLATE_MIX_BC+=("${mix_bc}")
+done
+
+echo "== llvm-link -> ${CUSTOM_OPS_BC}"
+"${LLVM_LINK}" "${OP_BC[@]}" "${TEMPLATE_BC[@]}" "${TEMPLATE_MIX_BC[@]}" \
+  -o "${CUSTOM_OPS_BC}"
+
+if [[ ! -s "${CUSTOM_OPS_BC}" ]]; then
+  echo "error: bitcode was not generated: ${CUSTOM_OPS_BC}" >&2
+  exit 1
+fi
+
+rm -f "${OP_BC[@]}" "${TEMPLATE_BC[@]}" "${TEMPLATE_MIX_BC[@]}"
+stat --format='%n %s bytes' "${CUSTOM_OPS_BC}"
+sha256sum "${CUSTOM_OPS_BC}"

--- a/python/triton/experimental/tle/language/dsa/ascend/custom_ops/common.py
+++ b/python/triton/experimental/tle/language/dsa/ascend/custom_ops/common.py
@@ -1,0 +1,15 @@
+# Copyright 2026- Xcoresigma Technology Co., Ltd
+from enum import IntEnum
+
+import triton.language as tl
+
+
+class SortImpl(IntEnum):
+    SORT_IMPL_BASE = 0
+    SORT_IMPL_S4096_K129_512 = 1
+    SORT_IMPL_S4096_K1_128_K2048 = 2
+
+
+SORT_IMPL_BASE = tl.constexpr(SortImpl.SORT_IMPL_BASE)
+SORT_IMPL_S4096_K129_512 = tl.constexpr(SortImpl.SORT_IMPL_S4096_K129_512)
+SORT_IMPL_S4096_K1_128_K2048 = tl.constexpr(SortImpl.SORT_IMPL_S4096_K1_128_K2048)

--- a/python/triton/experimental/tle/language/dsa/ascend/custom_ops/mem_ops/gather_gm_to_l1.cpp
+++ b/python/triton/experimental/tle/language/dsa/ascend/custom_ops/mem_ops/gather_gm_to_l1.cpp
@@ -1,0 +1,99 @@
+// Copyright 2026- Xcoresigma Technology Co., Ltd
+
+// Compiled standalone (AIC/Cube) into its own bitcode.
+#include "Utils.h"
+
+#define INTRINSIC_NO_ARGS(NAME) NAME()
+#define INTRINSIC(NAME, ...) NAME(__VA_ARGS__)
+
+constexpr int32_t INTR_BYTES_PER_BLOCK = 32;
+
+template <typename T> struct nd2nz_intrin_args {
+  __cbuf__ T *dst_ptr;
+  __gm__ T *src_ptr;
+  uint8_t sid;
+  uint16_t ndNum;
+  uint16_t nValue;
+  uint16_t dValue;
+  uint16_t srcNdMatrixStride;
+  uint16_t srcDValue;
+  uint16_t dstNzC0Stride;
+  uint16_t dstNzNStride;
+  uint16_t dstNzMatrixStride;
+};
+
+template <typename T>
+__aicore__ __attribute__((always_inline)) void
+copy_gm_to_cbuf_intrin_core(nd2nz_intrin_args<T> args) {
+  if constexpr (sizeof(T) == 2) {
+    INTRINSIC(copy_gm_to_cbuf_multi_nd2nz_b16, args.dst_ptr, args.src_ptr,
+              args.sid, args.ndNum, args.nValue, args.dValue,
+              args.srcNdMatrixStride, args.srcDValue, args.dstNzC0Stride,
+              args.dstNzNStride, args.dstNzMatrixStride);
+  } else if constexpr (sizeof(T) == 4) {
+    INTRINSIC(copy_gm_to_cbuf_multi_nd2nz_b32s, args.dst_ptr, args.src_ptr,
+              args.sid, args.ndNum, args.nValue, args.dValue,
+              args.srcNdMatrixStride, args.srcDValue, args.dstNzC0Stride,
+              args.dstNzNStride, args.dstNzMatrixStride);
+  }
+}
+
+// Generic row gather: out row i <- src row index[i]. Both src rows and the
+// index array live in GM and are assumed row-contiguous. Consecutive index
+// rows (index[i + 1] == index[i] + 1) are coalesced into one 2-row ND2NZ
+// copy.
+template <typename T>
+__aicore__ __attribute__((always_inline)) void
+gather_gm_to_l1_impl(memref_t<__gm__ T, 2> *src,
+                     memref_t<__gm__ int32_t, 2> *index, int64_t tile_size,
+                     int64_t cols, memref_t<__cbuf__ T, 4> *dst) {
+
+  auto gm_src = src->aligned + src->offset;
+  auto gm_idx = index->aligned + index->offset;
+  auto l1_ptr = dst->aligned + dst->offset;
+  int64_t n_tile_ceil = dst->strides[0] / dst->strides[2];
+  int64_t idx_stride = index->strides[0];
+  int64_t c0_size = INTR_BYTES_PER_BLOCK / sizeof(T);
+
+  for (int64_t i = 0; i < tile_size;) {
+    int64_t row = static_cast<int64_t>(gm_idx[i * idx_stride]);
+
+    __gm__ T *src_row = gm_src + row * cols;
+    __cbuf__ T *dst_row = l1_ptr + i * c0_size;
+
+    if (i + 1 < tile_size &&
+        static_cast<int64_t>(gm_idx[(i + 1) * idx_stride]) == row + 1) {
+      copy_gm_to_cbuf_intrin_core(nd2nz_intrin_args<T>{
+          dst_row, src_row, 0, 1, 2, static_cast<uint16_t>(cols), 0,
+          static_cast<uint16_t>(cols), static_cast<uint16_t>(n_tile_ceil), 1,
+          1});
+
+      i += 2;
+      continue;
+    }
+
+    copy_gm_to_cbuf_intrin_core(nd2nz_intrin_args<T>{
+        dst_row, src_row, 0, 1, 1, static_cast<uint16_t>(cols), 0, 0,
+        static_cast<uint16_t>(n_tile_ceil), 0, 1});
+
+    i += 1;
+  }
+}
+
+extern "C" {
+
+__aicore__ __attribute__((always_inline)) void
+_mlir_ciface_custom_gather_gm_to_l1_half(memref_t<__gm__ half, 2> *src,
+                                         memref_t<__gm__ int32_t, 2> *index,
+                                         int64_t tile_size, int64_t cols,
+                                         memref_t<__cbuf__ half, 4> *dst) {
+  gather_gm_to_l1_impl<half>(src, index, tile_size, cols, dst);
+}
+
+__aicore__ __attribute__((always_inline)) void
+_mlir_ciface_custom_gather_gm_to_l1_bf16(
+    memref_t<__gm__ bfloat16_t, 2> *src, memref_t<__gm__ int32_t, 2> *index,
+    int64_t tile_size, int64_t cols, memref_t<__cbuf__ bfloat16_t, 4> *dst) {
+  gather_gm_to_l1_impl<bfloat16_t>(src, index, tile_size, cols, dst);
+}
+}

--- a/python/triton/experimental/tle/language/dsa/ascend/custom_ops/mem_ops/gather_gm_to_ub.cpp
+++ b/python/triton/experimental/tle/language/dsa/ascend/custom_ops/mem_ops/gather_gm_to_ub.cpp
@@ -1,0 +1,67 @@
+// Copyright 2026- Xcoresigma Technology Co., Ltd
+
+// Compiled standalone (AIV/Vector) into its own bitcode.
+#include "Utils.h"
+
+#define INTRINSIC(NAME, ...) NAME(__VA_ARGS__)
+
+template <typename T>
+__aiv__ __attribute__((always_inline)) void
+copy_gm_to_ub_b16(__gm__ T *gm_ptr, __ubuf__ T *ub_ptr, uint16_t burst_cnt,
+                  uint32_t burst_len, uint32_t src_gap, uint32_t dst_gap) {
+  INTRINSIC(copy_gm_to_ubuf_align_b16, ub_ptr, gm_ptr, 0, burst_cnt, burst_len,
+            0, 0, src_gap, dst_gap);
+}
+
+// Generic row gather: out row i <- src row index[i]. Both src rows and the
+// index array live in GM and are assumed row-contiguous. Consecutive index
+// rows (index[i + 1] == index[i] + 1) are coalesced into one 2-burst copy.
+template <typename T>
+__aiv__ __attribute__((always_inline)) void
+gather_gm_to_ub_impl(memref_t<__gm__ T, 2> *src,
+                     memref_t<__gm__ int32_t, 2> *index, int64_t tile_size,
+                     int64_t cols, memref_t<__ubuf__ T, 2> *dst) {
+  auto gm_src = src->aligned + src->offset;
+  auto gm_idx = index->aligned + index->offset;
+  auto ub_dst = dst->aligned + dst->offset;
+
+  uint32_t row_bytes = static_cast<uint32_t>(cols * sizeof(T));
+  int64_t idx_stride = index->strides[0];
+  int64_t dst_stride = dst->strides[0];
+  uint32_t dst_gap = static_cast<uint32_t>((dst_stride - cols) * sizeof(T));
+
+  for (int64_t i = 0; i < tile_size;) {
+    int64_t row = static_cast<int64_t>(gm_idx[i * idx_stride]);
+
+    __gm__ T *src_row = gm_src + row * cols;
+    __ubuf__ T *dst_row = ub_dst + i * dst_stride;
+
+    if (i + 1 < tile_size &&
+        static_cast<int64_t>(gm_idx[(i + 1) * idx_stride]) == row + 1) {
+      copy_gm_to_ub_b16(src_row, dst_row, 2, row_bytes, 0, dst_gap);
+      i += 2;
+      continue;
+    }
+
+    copy_gm_to_ub_b16(src_row, dst_row, 1, row_bytes, 0, 0);
+    i += 1;
+  }
+}
+
+extern "C" {
+
+__aiv__ __attribute__((always_inline)) void
+_mlir_ciface_custom_gather_gm_to_ub_half(memref_t<__gm__ half, 2> *src,
+                                         memref_t<__gm__ int32_t, 2> *index,
+                                         int64_t tile_size, int64_t cols,
+                                         memref_t<__ubuf__ half, 2> *dst) {
+  gather_gm_to_ub_impl<half>(src, index, tile_size, cols, dst);
+}
+
+__aiv__ __attribute__((always_inline)) void
+_mlir_ciface_custom_gather_gm_to_ub_bf16(
+    memref_t<__gm__ bfloat16_t, 2> *src, memref_t<__gm__ int32_t, 2> *index,
+    int64_t tile_size, int64_t cols, memref_t<__ubuf__ bfloat16_t, 2> *dst) {
+  gather_gm_to_ub_impl<bfloat16_t>(src, index, tile_size, cols, dst);
+}
+}

--- a/python/triton/experimental/tle/language/dsa/ascend/custom_ops/registry.py
+++ b/python/triton/experimental/tle/language/dsa/ascend/custom_ops/registry.py
@@ -1,0 +1,252 @@
+# Copyright 2026- Xcoresigma Technology Co., Ltd
+from pathlib import Path
+
+import triton.language as tl
+import triton.language.extra.cann.extension as al
+
+CUSTOM_OPS_BITCODE = str(Path(__file__).with_name("custom_ops.bc").resolve())
+
+_GATHER_SUFFIX_BY_DTYPE = {tl.float16: "half", tl.bfloat16: "bf16"}
+
+
+def _element_dtype(value):
+    # Block-pointer tensors (tl.make_block_ptr) carry a nested dtype:
+    # pointer<block<[shape], dtype>>. Unwrap element_ty down to the scalar.
+    dtype = value.dtype
+    while hasattr(dtype, "element_ty"):
+        dtype = dtype.element_ty
+    return dtype
+
+
+def _gather_dtype_suffix(value, op_name):
+    dtype = _element_dtype(value)
+    suffix = _GATHER_SUFFIX_BY_DTYPE.get(dtype)
+    assert suffix is not None, (f"{op_name} only supports fp16/bf16, got {dtype}")
+    return suffix
+
+
+@al.register_custom_op
+class gather_gm_to_l1:
+    """
+    /*
+     * Function:
+     *   Gather fp16/bf16 rows from a row-contiguous 2D GM tensor by discrete
+     *   indices, write them into an L1/CBUF tensor and perform the ND2NZ
+     *   layout conversion for CUBE use. Output row i comes from source row
+     *   index[i]; adjacent indices (index[i + 1] == index[i] + 1) are merged
+     *   into a single two-row copy.
+     *
+     * Inputs:
+     *   src: row-contiguous 2D fp16/bf16 source tensor in GM.
+     *   index: 2D int32 index tensor in GM (shape (N, 1), stride (1, 1));
+     *     output row i takes its data from source row index[i] (0-based row
+     *     number); the starting offset of the indices is expressed through
+     *     the block ptr offsets, so no extra parameter is needed.
+     *   tile_size: number of data rows to gather.
+     *   D: number of fp16/bf16 elements in each source row.
+     *
+     * Outputs:
+     *   out: required 4D L1/CBUF fp16/bf16 destination tensor (same dtype as
+     *     src), corresponding to dst in the C++ ABI; the gathered result is
+     *     written into this tensor directly and it is returned on the Python
+     *     side.
+     */
+    """
+
+    core = al.CORE.CUBE
+    pipe = al.PIPE.PIPE_MTE2
+    mode = al.MODE.SIMD
+
+    def __init__(self, src, index, tile_size, D, out=None):
+        assert out is not None, "out buffer is required"
+        assert _element_dtype(out) == _element_dtype(src), (
+            f"gather_gm_to_l1 requires out dtype ({_element_dtype(out)}) "
+            f"to match src dtype ({_element_dtype(src)})")
+        assert _element_dtype(index) == tl.int32, (f"gather_gm_to_l1 requires int32 index, "
+                                                   f"got {_element_dtype(index)}")
+        self.symbol = ("custom_gather_gm_to_l1_" + _gather_dtype_suffix(src, "gather_gm_to_l1"))
+        self.bitcode = CUSTOM_OPS_BITCODE
+
+
+@al.register_custom_op
+class gather_gm_to_ub:
+    """
+    /*
+     * Function:
+     *   On the VECTOR core, gather fp16/bf16 rows from a row-contiguous 2D
+     *   GM tensor by index and write them into a UB tensor. Output row i
+     *   comes from source row index[i]; adjacent indices
+     *   (index[i + 1] == index[i] + 1) are merged into a single two-row DMA
+     *   copy.
+     *
+     * Inputs:
+     *   src: row-contiguous 2D fp16/bf16 source tensor in GM.
+     *   index: 2D int32 index tensor in GM (shape (N, 1), stride (1, 1));
+     *     output row i takes its data from source row index[i] (0-based row
+     *     number); the starting offset of the indices is expressed through
+     *     the block ptr offsets, so no extra parameter is needed.
+     *   tile_size: number of data rows to gather.
+     *   D: number of fp16/bf16 elements copied from each source row.
+     *
+     * Outputs:
+     *   out: required 2D UB fp16/bf16 destination tensor (same dtype as
+     *     src), corresponding to dst in the C++ ABI; the stride of the first
+     *     dimension must be no smaller than D. The gathered result is
+     *     written into this tensor directly and it is returned on the
+     *     Python side.
+     */
+    """
+
+    core = al.CORE.VECTOR
+    pipe = al.PIPE.PIPE_MTE2
+    mode = al.MODE.SIMD
+
+    def __init__(self, src, index, tile_size, D, out=None):
+        assert out is not None, "out buffer is required"
+        assert _element_dtype(out) == _element_dtype(src), (
+            f"gather_gm_to_ub requires out dtype ({_element_dtype(out)}) "
+            f"to match src dtype ({_element_dtype(src)})")
+        assert _element_dtype(index) == tl.int32, (f"gather_gm_to_ub requires int32 index, "
+                                                   f"got {_element_dtype(index)}")
+        self.symbol = ("custom_gather_gm_to_ub_" + _gather_dtype_suffix(src, "gather_gm_to_ub"))
+        self.bitcode = CUSTOM_OPS_BITCODE
+
+
+@al.register_custom_op
+class sort_1d_pack:
+    """
+    /*
+     * Function:
+     *   Sort a 1D float tensor in UB and, according to sort_impl, select the
+     *   matching TopK sort implementation, emitting the best TOPK compact
+     *   proposals. Each proposal occupies two float slots holding the value
+     *   and, in the second slot, the encoded index.
+     *
+     * Inputs:
+     *   src: 1D float input tensor in UB.
+     *   tmp_buf: UB scratch tensor holding intermediate sort/merge results.
+     *   descending: sort descending when True, ascending when False.
+     *   TOPK: number of proposals to keep.
+     *   index_offset: offset added to each raw index.
+     *   sort_impl: sort implementation number; the device side picks the
+     *     matching sort path from it based on the input size.
+     *
+     * Outputs:
+     *   out: required UB float destination tensor, corresponding to
+     *     dst_proposals in the C++ ABI; must hold at least 2 * TOPK float
+     *     slots storing the TOPK proposals compactly as
+     *     [value, encoded_index]. It is returned on the Python side.
+     */
+    """
+
+    core = al.CORE.VECTOR
+    pipe = al.PIPE.PIPE_V
+    mode = al.MODE.SIMD
+
+    def __init__(self, src, tmp_buf, descending, TOPK, index_offset, sort_impl, out=None):
+        assert out
+        assert _element_dtype(src) == tl.float32, (f"sort_1d_pack only supports fp32 src, got {_element_dtype(src)}")
+        assert _element_dtype(tmp_buf) == tl.float32, (f"sort_1d_pack only supports fp32 tmp_buf, "
+                                                       f"got {_element_dtype(tmp_buf)}")
+        assert _element_dtype(out) == tl.float32, (f"sort_1d_pack only supports fp32 out, got {_element_dtype(out)}")
+        self.symbol = "custom_sort_1d_pack_float"
+        self.bitcode = CUSTOM_OPS_BITCODE
+        self.extra_buffers = [(tl.float16, 0)]
+
+
+@al.register_custom_op
+class merge_exhaust_sort4:
+    """
+    /*
+     * Function:
+     *   Perform one exhaustion-mode merge over up to four sorted proposal
+     *   ways in UB, emitting the safely determined sorted prefix and the
+     *   number of proposals actually consumed from each way. All offsets
+     *   and lengths are counted in proposals, not float slots.
+     *
+     * Inputs:
+     *   src_proposals: UB tensor holding multiple sorted compact proposal
+     *     ways.
+     *   ways: number of active input ways; must match the number of
+     *     non-zero values among len0..len3.
+     *   off0, off1, off2, off3: starting offset of each of the four input
+     *     ways, in proposals.
+     *   len0, len1, len2, len3: number of proposals available in each of
+     *     the four input ways; 0 marks the way as inactive.
+     *
+     * Outputs:
+     *   out: required two-element output sequence [dst_proposals,
+     *     consumed_out]:
+     *     - out[0] / dst_proposals: UB float tensor receiving the safely
+     *       determined sorted proposal prefix of the merge, corresponding
+     *       to dst_proposals in the C++ ABI.
+     *     - out[1] / consumed_out: UB tensor holding at least four int32
+     *       elements, recording in order the number of proposals actually
+     *       consumed this round from original ways 0 through 3,
+     *       corresponding to consumed_out in the C++ ABI.
+     *   The Python side returns (dst_proposals, consumed_out) in the same
+     *   order.
+     */
+    """
+
+    core = al.CORE.VECTOR
+    pipe = al.PIPE.PIPE_V
+    mode = al.MODE.SIMD
+
+    def __init__(self, src_proposals, ways, off0, off1, off2, off3, len0, len1, len2, len3, out=None):
+        assert out
+        assert len(out) == 2, ("merge_exhaust_sort4 requires out to be "
+                               "[dst_proposals, consumed_out]")
+        assert _element_dtype(src_proposals) == tl.float32, (f"merge_exhaust_sort4 only supports fp32 src_proposals, "
+                                                             f"got {_element_dtype(src_proposals)}")
+        assert _element_dtype(out[0]) == tl.float32, (f"merge_exhaust_sort4 only supports fp32 out[0], "
+                                                      f"got {_element_dtype(out[0])}")
+        assert _element_dtype(out[1]) == tl.int32, (f"merge_exhaust_sort4 only supports int32 out[1], "
+                                                    f"got {_element_dtype(out[1])}")
+        self.symbol = "custom_merge_exhaust_sort4_float"
+        self.bitcode = CUSTOM_OPS_BITCODE
+        self.extra_buffers = [(tl.float16, 0)]
+
+
+@al.register_custom_op
+class unpack_sort:
+    """
+    /*
+     * Function:
+     *   Split compactly stored TopK proposals in UB into separate float
+     *   values and int32 indices. Each input proposal consists of two
+     *   float-sized slots.
+     *
+     * Inputs:
+     *   src_proposals: UB tensor holding at least topk compact proposals;
+     *     its valid view must contain exactly 2 * topk float slots.
+     *   topk: number of proposals to split.
+     *
+     * Outputs:
+     *   out: required two-element output sequence [dst_value, dst_index]:
+     *     - out[0] / dst_value: UB float tensor holding at least topk
+     *       elements, receiving the value of each proposal, corresponding
+     *       to dst_value in the C++ ABI.
+     *     - out[1] / dst_index: UB int32 tensor holding at least topk
+     *       elements, receiving the decoded index of each proposal,
+     *       corresponding to dst_index in the C++ ABI.
+     *   The Python side returns (dst_value, dst_index) in the same order.
+     */
+    """
+
+    core = al.CORE.VECTOR
+    pipe = al.PIPE.PIPE_V
+    mode = al.MODE.SIMD
+
+    def __init__(self, src_proposals, topk, out=None):
+        assert out
+        assert len(out) == 2, ("unpack_sort requires out to be [dst_value, dst_index]")
+        assert _element_dtype(src_proposals) == tl.float32, (f"unpack_sort only supports fp32 src_proposals, "
+                                                             f"got {_element_dtype(src_proposals)}")
+        assert _element_dtype(out[0]) == tl.float32, (f"unpack_sort only supports fp32 out[0], "
+                                                      f"got {_element_dtype(out[0])}")
+        assert _element_dtype(out[1]) == tl.int32, (f"unpack_sort only supports int32 out[1], "
+                                                    f"got {_element_dtype(out[1])}")
+        self.symbol = "custom_unpack_sort_float"
+        self.bitcode = CUSTOM_OPS_BITCODE
+        self.extra_buffers = [(tl.float16, 0)]

--- a/python/triton/experimental/tle/language/dsa/ascend/custom_ops/sort_ops/merge_pack_sort.cpp
+++ b/python/triton/experimental/tle/language/dsa/ascend/custom_ops/sort_ops/merge_pack_sort.cpp
@@ -1,0 +1,135 @@
+// Copyright 2026- Xcoresigma Technology Co., Ltd
+
+// Compiled standalone (AIV/Vector) into its own bitcode.
+/**
+ * =====================================================================
+ *
+ *   - This file uses vmrgsort4 in *truncated/exhaustion mode*
+ *     (config[12] = isAllStored = 1): the merge stops as soon as any way's
+ *     on-chip data is exhausted, without requiring all 4 ways to drain.
+ *   - After each vmrgsort4, VMS4_SR is read back via get_vms4_sr(). The
+ *     register packs the actually consumed proposal count of each way into
+ *     16-bit fields:
+ *         VMS4_SR[15:0]  = consumed by way 0
+ *         VMS4_SR[31:16] = consumed by way 1
+ *         VMS4_SR[47:32] = consumed by way 2
+ *         VMS4_SR[63:48] = consumed by way 3
+ *   - Software advances each way's read cursor and remaining count from
+ *     these values, and writes the consumed counts out to decide "how much
+ *     to load from each way next time, and from where".
+ *
+ * Data format:
+ *   proposal = [value (f32), index (i32 reinterpreted as f32)], 8 bytes.
+ *   Input src_proposals[N*2] f32, segmented into blocks of block_size
+ *   proposals, descending within each block.
+ *
+ * config bit fields (confirmed by the vmrgsort4 wrapper in intrisics.h):
+ *   config = (repeat & 0xff) | ((maskSignal & 0xf) << 8) | ((isAllStored & 1)
+ * << 12) maskSignal: 0x3=2 ways, 0x7=3 ways, 0xf=4 ways
+ *
+ */
+
+#include "DMA/DMAUtils.h"
+#include "Vector/Sort/SortUtils.h"
+#include "Vector/VecUtils.h"
+#include "sort_common.h"
+
+extern "C" {
+
+///
+/// Fully controlled from the Python side: which ways, each way's starting
+/// proposal offset in src, each way's length, and the output buffer. The C++
+/// side only performs a single (exhaustion-mode) vmrgsort4 and reports the
+/// per-way consumed counts. The multi-level merge loop, buffer allocation
+/// and cursor advancement are all composed from this primitive on the
+/// Python side.
+///
+/// Note: the function returns void; outputs are written back through the
+/// dst_proposals / consumed_out pointers.
+///
+/// src_proposals: [in] UB proposal buffer (all ways live in it; starts given by
+/// off*) ways:          [in] number of active ways (2/3/4) off0..off3:    [in]
+/// starting proposal offset of each way (in proposals; unused ways pass 0)
+/// len0..len3:    [in] length of each way in proposals (unused ways pass 0)
+/// dst_proposals: [out, written via pointer] merged output (safe prefix first)
+/// consumed_out:  [out, written via pointer] tensor<4 x i32> — per-way consumed
+/// counts this round (decoded from VMS4_SR)
+__aiv__ __attribute__((always_inline)) void
+_mlir_ciface_custom_merge_exhaust_sort4_float(
+    memref_t<__ubuf__ float, 1> *src_proposals, int64_t ways, int64_t off0,
+    int64_t off1, int64_t off2, int64_t off3, int64_t len0, int64_t len1,
+    int64_t len2, int64_t len3, memref_t<__ubuf__ float, 1> *dst_proposals,
+    memref_t<__ubuf__ int32_t, 1> *consumed_out) {
+  constexpr int64_t npp = PROPOSALS_BYTES / sizeof(float); // 2
+  auto src_ptr = src_proposals->aligned + src_proposals->offset;
+  auto dst_ptr = dst_proposals->aligned + dst_proposals->offset;
+  auto cons_ptr = consumed_out->aligned + consumed_out->offset;
+
+  int64_t offs[4] = {off0, off1, off2, off3};
+  int64_t lns[4] = {len0, len1, len2, len3};
+
+  // ★ Key point: compact the non-empty ways into consecutive lanes
+  //   0..(active-1). vmrgsort4_exhaust uses mask = (1<<ways)-1 and assumes
+  //   the active ways are laid out contiguously from lane 0. But the caller
+  //   places the 4 ways in fixed slots and marks empty ways with length 0;
+  //   merging tail segments can leave holes ("a middle way exhausted
+  //   first", e.g. l0>0, l1=0, l2>0). Feeding the fixed slots directly
+  //   would make the mask select a zero-length lane -> vmrgsort4 illegal
+  //   configuration (VEC illegal config). So collect only the ways with
+  //   len>0 into consecutive lanes, record their original indices, and
+  //   scatter each lane's consumed count back to its original slot after
+  //   the merge.
+  __ubuf__ float *xn[4];
+  uint32_t lens[4] = {0, 0, 0, 0};
+  int orig_idx[4] = {0, 0, 0, 0}; // compacted lane w -> original slot
+  int active = 0;
+  for (int i = 0; i < 4; ++i) {
+    if (lns[i] > 0) {
+      xn[active] = src_ptr + offs[i] * npp;
+      lens[active] = (uint32_t)lns[i];
+      orig_idx[active] = i;
+      active++;
+    }
+  }
+
+  // Zero the consumed counts of all 4 ways first (empty ways always
+  // consume 0)
+  for (int i = 0; i < 4; ++i)
+    *(cons_ptr + i) = 0;
+
+  if (active == 0) {
+    return; // no data, no-op
+  }
+
+  if (active == 1) {
+    // A single way left: no merge needed, copy the remainder straight to
+    // dst (standard k-way merge tail optimization). Note: vmrgsort4 does
+    // not support 1 way (mask=0x1 is illegal), so it must be special-cased.
+    int64_t cnt = lens[0];
+    memref_t<__ubuf__ float, 1> from{src_proposals->aligned,
+                                     src_proposals->allocated,
+                                     src_proposals->offset +
+                                         offs[orig_idx[0]] * npp,
+                                     {cnt * npp},
+                                     {1}};
+    memref_t<__ubuf__ float, 1> to{dst_proposals->aligned,
+                                   dst_proposals->allocated,
+                                   dst_proposals->offset,
+                                   {cnt * npp},
+                                   {1}};
+    copy_ubuf_to_ubuf_1d_core(&from, &to);
+    *(cons_ptr + orig_idx[0]) = (int32_t)cnt;
+    return;
+  }
+
+  // active >= 2: normal exhaustion merge (lanes contiguous after
+  // compaction, mask is valid)
+  uint64_t sr = vmrgsort4_exhaust<float>(dst_ptr, xn, lens, active);
+
+  // Scatter the consumed count of compacted lane w back to its original
+  // slot orig_idx[w]
+  for (int w = 0; w < active; ++w)
+    *(cons_ptr + orig_idx[w]) = (int32_t)vms4_consumed(sr, w);
+}
+
+} // extern "C"

--- a/python/triton/experimental/tle/language/dsa/ascend/custom_ops/sort_ops/sort_1d_pack.cpp
+++ b/python/triton/experimental/tle/language/dsa/ascend/custom_ops/sort_ops/sort_1d_pack.cpp
@@ -1,0 +1,33 @@
+// Copyright 2026- Xcoresigma Technology Co., Ltd
+
+// Compiled standalone (AIV/Vector) into its own bitcode.
+#include "sort_base.h"
+#include "sort_s4096_k129_512.h"
+#include "sort_s4096_k1_128_k2048.h"
+
+extern "C" {
+
+__aiv__ __attribute__((always_inline)) void
+_mlir_ciface_custom_sort_1d_pack_float(
+    memref_t<__ubuf__ float, 1> *src, memref_t<__ubuf__ float, 1> *tmp_buf,
+    bool descending, int64_t topk, int64_t index_offset, int64_t sort_impl,
+    memref_t<__ubuf__ float, 1> *dst_proposals) {
+  switch (sort_impl) {
+  case 0:
+    sort_base_impl(src, tmp_buf, descending, topk, index_offset, dst_proposals);
+    return;
+  case 1:
+    sort_s4096_k129_512_impl(src, tmp_buf, descending, topk, index_offset,
+                             dst_proposals);
+    return;
+  case 2:
+    sort_s4096_k1_128_k2048_impl(src, tmp_buf, descending, topk, index_offset,
+                                 dst_proposals);
+    return;
+  default:
+    sort_base_impl(src, tmp_buf, descending, topk, index_offset, dst_proposals);
+    return;
+  }
+}
+
+} // extern "C"

--- a/python/triton/experimental/tle/language/dsa/ascend/custom_ops/sort_ops/sort_base.h
+++ b/python/triton/experimental/tle/language/dsa/ascend/custom_ops/sort_ops/sort_base.h
@@ -1,0 +1,777 @@
+// Copyright 2026- Xcoresigma Technology Co., Ltd
+
+// Included only by custom_ops_aiv.cpp.
+
+#include "Utils.h"
+#include "Vector/Arange/ArangeUtils.h"
+#include "Vector/Cast/CastUtils.h"
+#include "Vector/Sort/SortUtils.h"
+
+template <typename T>
+__aiv__ __attribute__((always_inline)) void check_inputs_of_sort_1d_with_index(
+    memref_t<__ubuf__ T, 1> *src, memref_t<__ubuf__ T, 1> *dst_value,
+    memref_t<__ubuf__ int32_t, 1> *dst_index = nullptr) {
+#ifdef ENABLE_CPU_TRACE_INTRINSIC
+  auto src_ptr = src->aligned + src->offset;
+  auto dst_value_ptr = dst_value->aligned + dst_value->offset;
+  auto dst_index_ptr = dst_index->aligned + dst_index->offset;
+  assert((src->strides[0] == 1) && "The src must be continues.");
+  assert((dst_value->strides[0] == 1) && "The dst_value must be continues.");
+  if (dst_index) {
+    assert((dst_index->strides[0] == 1) && "The dst_index must be continues.");
+  }
+#endif
+}
+
+template <typename T>
+__aiv__ __attribute__((always_inline)) void lower_sort_for_last_axis_is_one(
+    memref_t<__ubuf__ T, 1> *src, memref_t<__ubuf__ T, 1> *dst_value,
+    memref_t<__ubuf__ int32_t, 1> *dst_index, bool need_index) {
+  if (need_index) {
+    auto dst_index_ptr = dst_index->aligned + dst_index->offset;
+    brc_scalar_core_1d(0, dst_index_ptr, dst_index->sizes[0]);
+  }
+  copy_ubuf_to_ubuf_1d_core(src, dst_value);
+}
+
+template <typename T>
+__aiv__ __attribute__((always_inline)) void
+prepare_src_value(memref_t<__ubuf__ T, 1> *src, memref_t<__ubuf__ T, 1> *dst,
+                  int64_t real_num, int64_t sort_num, bool descending) {
+  auto src_ptr = src->aligned + src->offset;
+  int64_t fill_num = sort_num - real_num;
+  // Since the sorting instruction only supports descending sorting, the data
+  // needs to be reversed for sorting in ascending order, and then reversed
+  // after the sorting is completed. Therefore, the maximum value needs to be
+  // filled to ensure that it does not affect the sorting result.
+  if (!descending) {
+    INTRINSIC(set_flag, PIPE_V, PIPE_S, LIB_EVENT_ID0);
+    INTRINSIC(wait_flag, PIPE_V, PIPE_S, LIB_EVENT_ID0);
+    for (int64_t i = 0; i < fill_num; ++i) {
+#ifdef ENABLE_CPU_TRACE_INTRINSIC
+      if constexpr (std::is_same<T, half>::value) {
+        *(src_ptr + real_num + i) =
+            half({static_cast<unsigned short>(FLOAT_NAN)});
+      } else {
+        *(src_ptr + real_num + i) = static_cast<T>(FLOAT_NAN);
+      }
+#else
+      *(src_ptr + real_num + i) = static_cast<T>(FLOAT_NAN);
+#endif
+    }
+    INTRINSIC(set_flag, PIPE_S, PIPE_V, LIB_EVENT_ID0);
+    INTRINSIC(wait_flag, PIPE_S, PIPE_V, LIB_EVENT_ID0);
+
+    // for ascend sort, we need reverse data, because vbs/vms only support
+    // descend.
+    src->sizes[0] = sort_num;
+    if constexpr (sizeof(T) == 4) {
+      memref_t<__ubuf__ int32_t, 1> src_s32;
+      view_as<T, int32_t, 1>(src, &src_s32);
+      memref_t<__ubuf__ int32_t, 1> dst_s32;
+      view_as<T, int32_t, 1>(dst, &dst_s32);
+      vector_eltwise_vs_1d<VectorOpTy::VADDS, int32_t>(&src_s32, S32_MIN_VALUE,
+                                                       &dst_s32);
+    } else {
+      memref_t<__ubuf__ int16_t, 1> src_s16;
+      view_as<T, int16_t, 1>(src, &src_s16);
+      memref_t<__ubuf__ int16_t, 1> dst_s16;
+      view_as<T, int16_t, 1>(dst, &dst_s16);
+      vector_eltwise_vs_1d<VectorOpTy::VADDS, int16_t>(&src_s16, S16_MIN_VALUE,
+                                                       &dst_s16);
+    }
+    src->sizes[0] = real_num;
+    return;
+  }
+  // In descending order, the minimum value needs to be filled to ensure that
+  // it does not affect the sorting result.
+  INTRINSIC(set_flag, PIPE_V, PIPE_S, LIB_EVENT_ID0);
+  INTRINSIC(wait_flag, PIPE_V, PIPE_S, LIB_EVENT_ID0);
+  for (int64_t i = 0; i < fill_num; ++i) {
+#ifdef ENABLE_CPU_TRACE_INTRINSIC
+    if constexpr (std::is_same<T, half>::value) {
+      *(src_ptr + real_num + i) =
+          half({static_cast<unsigned short>(FLOAT_NEG_INF)});
+    } else {
+      *(src_ptr + real_num + i) = static_cast<T>(FLOAT_NEG_INF);
+    }
+#else
+    *(src_ptr + real_num + i) = static_cast<T>(FLOAT_NEG_INF);
+#endif
+  }
+  INTRINSIC(set_flag, PIPE_S, PIPE_V, LIB_EVENT_ID0);
+  INTRINSIC(wait_flag, PIPE_S, PIPE_V, LIB_EVENT_ID0);
+}
+
+__aiv__ __attribute__((always_inline)) static void
+prepare_src_index(memref_t<__ubuf__ int32_t, 1> *src_index, int64_t real_num,
+                  int64_t sort_num, int64_t index_offset = 0) {
+  src_index->sizes[0] = sort_num;
+  arange_1d(src_index, index_offset, 1);
+  src_index->sizes[0] = real_num;
+}
+
+template <typename T>
+__aiv__ __attribute__((always_inline)) void
+block_sort(memref_t<__ubuf__ T, 1> *src_value,
+           memref_t<__ubuf__ int32_t, 1> *src_index,
+           memref_t<__ubuf__ T, 1> *dst, int64_t real_num, int64_t sort_num) {
+  auto repeat = sort_num / BIT_SORT_NUM_PER_REPEAT;
+  auto sort_num_per_intrinsic = INTR_MAX_REPEAT_CNTS * BIT_SORT_NUM_PER_REPEAT;
+  auto num_per_proposal = PROPOSALS_BYTES / sizeof(T);
+  auto dst_ptr = dst->aligned + dst->offset;
+  auto src_value_ptr = src_value->aligned + src_value->offset;
+  auto src_index_ptr = src_index->aligned + src_index->offset;
+  if (repeat >= INTR_MAX_REPEAT_CNTS) [[unlikely]] {
+    for (int64_t i = 0; i < repeat / INTR_MAX_REPEAT_CNTS; ++i) {
+      INTRINSIC(
+          vbitsort, dst_ptr + i * sort_num_per_intrinsic * num_per_proposal,
+          src_value_ptr + i * sort_num_per_intrinsic,
+          (__ubuf__ uint32_t *)(src_index_ptr + i * sort_num_per_intrinsic),
+          INTR_MAX_REPEAT_CNTS); // repeat
+    }
+  }
+
+  if (repeat % INTR_MAX_REPEAT_CNTS != 0) [[likely]] {
+    auto loop_num = repeat / INTR_MAX_REPEAT_CNTS;
+    INTRINSIC(vbitsort,
+              dst_ptr + loop_num * sort_num_per_intrinsic * num_per_proposal,
+              src_value_ptr + loop_num * sort_num_per_intrinsic,
+              (__ubuf__ uint32_t *)(src_index_ptr +
+                                    loop_num * sort_num_per_intrinsic),
+              repeat % INTR_MAX_REPEAT_CNTS); // repeat
+  }
+}
+
+template <typename T>
+__aiv__ __attribute__((always_inline)) void
+lower_vms_quotient(memref_t<__ubuf__ T, 1> *src, memref_t<__ubuf__ T, 1> *dst,
+                   int64_t &merge_times, int64_t factor, int64_t sort_num) {
+  auto num_per_proposal = PROPOSALS_BYTES / sizeof(T);
+  int64_t list_interval_offset = factor * num_per_proposal;
+  int64_t quotient_repeat = sort_num / factor / MERGE_SORT_MAX_PROPOSALS_LIST;
+  uint64_t list_num = factor & (int64_t)MAX_UINT16;
+  auto src_ptr = src->aligned + src->offset;
+  auto dst_ptr = dst->aligned + dst->offset;
+
+  // Xn[15:0] is list 0 address
+  // Xn[31:16] is list 1 address
+  // Xn[47:32] is list 2 address
+  // Xn[63:48] is list 3 address
+  __ubuf__ T *xn[4] = {
+      merge_times % 2 ? src_ptr : dst_ptr,
+      merge_times % 2 ? src_ptr + list_interval_offset
+                      : dst_ptr + list_interval_offset,
+      merge_times % 2 ? src_ptr + list_interval_offset * 2
+                      : dst_ptr + list_interval_offset * 2,
+      merge_times % 2 ? src_ptr + list_interval_offset * 3
+                      : dst_ptr + list_interval_offset * 3,
+  };
+
+  // xm[15:0]: number of structures in input list 0
+  // xm[31:16]: number of structures in input list 1
+  // xm[47:32]: number of structures in input list 2
+  // xm[63:48]: number of structures in input list 3
+  uint64_t xm =
+      ((list_num | (list_num << 16)) | (list_num << 32)) | (list_num << 48);
+
+  // Enabled repeat mode and disable exhaustion mode when running vmrgsort4
+  // (config[12] = 0 and config[7:0] > 1 and config[11:8] means whether the
+  // four lists valid?)
+  uint64_t config =
+      (WAY4_CONFIG_MODE | (quotient_repeat & INTR_MAX_REPEAT_CNTS));
+  INTRINSIC(vmrgsort4, merge_times % 2 ? dst_ptr : src_ptr,
+            xn,      // the address of each list
+            xm,      // the number of each list
+            config); // config
+}
+
+template <typename T>
+__aiv__ __attribute__((always_inline)) void
+lower_vms_remainder(memref_t<__ubuf__ T, 1> *src, memref_t<__ubuf__ T, 1> *dst,
+                    int64_t &merge_times, int64_t factor, int64_t sort_num,
+                    merge_remainder_info *merge_remainder) {
+  auto num_per_proposal = PROPOSALS_BYTES / sizeof(T);
+  int64_t quotient_repeat = sort_num / factor / MERGE_SORT_MAX_PROPOSALS_LIST;
+  int64_t cur_remainder = sort_num / factor % MERGE_SORT_MAX_PROPOSALS_LIST;
+  uint64_t list_num = factor & (int64_t)MAX_UINT16;
+  auto src_ptr = src->aligned + src->offset;
+  auto dst_ptr = dst->aligned + dst->offset;
+  // Calculate the offset of cur_remainder
+  auto base_offset = quotient_repeat * factor * MERGE_SORT_MAX_PROPOSALS_LIST *
+                     num_per_proposal;
+
+  if (cur_remainder == 0 && merge_remainder->merge_remainder_flag) {
+    memref_t<__ubuf__ T, 1> src_tmp{
+        src->aligned,
+        src->allocated,
+        static_cast<int64_t>(src->offset + base_offset),
+        {static_cast<int64_t>(merge_remainder->merge_remainder_num *
+                              num_per_proposal)},
+        {1}};
+    memref_t<__ubuf__ T, 1> dst_tmp{
+        dst->aligned,
+        dst->allocated,
+        static_cast<int64_t>(dst->offset + base_offset),
+        {static_cast<int64_t>(merge_remainder->merge_remainder_num *
+                              num_per_proposal)},
+        {1}};
+    // At this point, there is only one list, no need to merge
+    copy_ubuf_to_ubuf_1d_core(merge_times % 2 ? &src_tmp : &dst_tmp,
+                              merge_times % 2 ? &dst_tmp : &src_tmp);
+  } else if (cur_remainder == 1) {
+    if (merge_remainder->merge_remainder_num > 0) {
+      // Perform a 2-way sort, list1 is the tail block left over from the
+      // previous round(merge_remainder_num)
+      __ubuf__ T *xn[2] = {
+          merge_times % 2 ? src_ptr + base_offset : dst_ptr + base_offset,
+          merge_times % 2 ? src_ptr + base_offset + factor * num_per_proposal
+                          : dst_ptr + base_offset + factor * num_per_proposal,
+      };
+      // 0011(proposal list) + 000000001(repeat)
+      uint64_t config = WAY2_CONFIG_MODE | 1;
+      uint64_t xm = list_num |
+                    ((merge_remainder->merge_remainder_num & MAX_UINT16) << 16);
+      INTRINSIC(vmrgsort4,
+                merge_times % 2 ? dst_ptr + base_offset : src_ptr + base_offset,
+                xn,      // the address of each list
+                xm,      // the number of each list
+                config); // config
+    } else {
+      memref_t<__ubuf__ T, 1> src_tmp{
+          src->aligned,
+          src->allocated,
+          static_cast<int64_t>(src->offset + base_offset),
+          {static_cast<int64_t>(list_num * num_per_proposal)},
+          {1}};
+      memref_t<__ubuf__ T, 1> dst_tmp{
+          dst->aligned,
+          dst->allocated,
+          static_cast<int64_t>(dst->offset + base_offset),
+          {static_cast<int64_t>(list_num * num_per_proposal)},
+          {1}};
+      // At this point, there is only one list, no need to merge
+      copy_ubuf_to_ubuf_1d_core(merge_times % 2 ? &src_tmp : &dst_tmp,
+                                merge_times % 2 ? &dst_tmp : &src_tmp);
+    }
+
+    // After sorting, a tail block is formed for the next round of merge
+    merge_remainder->merge_remainder_flag = true;
+    merge_remainder->merge_remainder_num += factor;
+  } else if (cur_remainder == 2) {
+    if (merge_remainder->merge_remainder_num > 0) {
+      // Perform a 3-way sort, list2 is the tail block left over from the
+      // previous round(merge_remainder_num)
+      __ubuf__ T *xn[3] = {
+          merge_times % 2 ? src_ptr + base_offset : dst_ptr + base_offset,
+          merge_times % 2 ? src_ptr + base_offset + factor * num_per_proposal
+                          : dst_ptr + base_offset + factor * num_per_proposal,
+          merge_times % 2
+              ? src_ptr + base_offset + factor * num_per_proposal * 2
+              : dst_ptr + base_offset + factor * num_per_proposal * 2,
+      };
+      // 0111(proposal list) + 000000001(repeat)
+      uint64_t config = WAY3_CONFIG_MODE | 1;
+      uint64_t xm = (list_num | (list_num << 16)) |
+                    ((merge_remainder->merge_remainder_num & MAX_UINT16) << 32);
+      INTRINSIC(vmrgsort4,
+                merge_times % 2 ? dst_ptr + base_offset : src_ptr + base_offset,
+                xn,      // the address of each list
+                xm,      // the number of each list
+                config); // config
+    } else {
+      // Perform a 2-way sort
+      __ubuf__ T *xn[2] = {
+          merge_times % 2 ? src_ptr + base_offset : dst_ptr + base_offset,
+          merge_times % 2 ? src_ptr + base_offset + factor * num_per_proposal
+                          : dst_ptr + base_offset + factor * num_per_proposal,
+      };
+      // 0011(proposal list) + 000000001(repeat)
+      uint64_t config = WAY2_CONFIG_MODE | 1;
+      uint64_t xm = list_num | (list_num << 16);
+      INTRINSIC(vmrgsort4,
+                merge_times % 2 ? dst_ptr + base_offset : src_ptr + base_offset,
+                xn,      // the address of each list
+                xm,      // the number of each list
+                config); // config
+    }
+
+    // After sorting, a tail block is formed for the next round of merge
+    merge_remainder->merge_remainder_flag = true;
+    merge_remainder->merge_remainder_num += factor * 2;
+  } else if (cur_remainder == 3) {
+    if (merge_remainder->merge_remainder_num > 0) {
+      // Perform a 4-way sort, list3 is the tail block left over from the
+      // previous round(merge_remainder_num)
+      __ubuf__ T *xn[4] = {
+          merge_times % 2 ? src_ptr + base_offset : dst_ptr + base_offset,
+          merge_times % 2 ? src_ptr + base_offset + factor * num_per_proposal
+                          : dst_ptr + base_offset + factor * num_per_proposal,
+          merge_times % 2
+              ? src_ptr + base_offset + factor * num_per_proposal * 2
+              : dst_ptr + base_offset + factor * num_per_proposal * 2,
+          merge_times % 2
+              ? src_ptr + base_offset + factor * num_per_proposal * 3
+              : dst_ptr + base_offset + factor * num_per_proposal * 3,
+      };
+      // 1111(proposal list) + 000000001(repeat)
+      uint64_t config = WAY4_CONFIG_MODE | 1;
+      uint64_t xm = ((list_num | (list_num << 16)) | (list_num << 32)) |
+                    ((merge_remainder->merge_remainder_num & MAX_UINT16) << 48);
+      INTRINSIC(vmrgsort4,
+                merge_times % 2 ? dst_ptr + base_offset : src_ptr + base_offset,
+                xn,      // the address of each list
+                xm,      // the number of each list
+                config); // config
+    } else {
+      // Perform a 3-way sort
+      __ubuf__ T *xn[3] = {
+          merge_times % 2 ? src_ptr + base_offset : dst_ptr + base_offset,
+          merge_times % 2 ? src_ptr + base_offset + factor * num_per_proposal
+                          : dst_ptr + base_offset + factor * num_per_proposal,
+          merge_times % 2
+              ? src_ptr + base_offset + factor * num_per_proposal * 2
+              : dst_ptr + base_offset + factor * num_per_proposal * 2,
+      };
+      // 0111(proposal list) + 000000001(repeat)
+      uint64_t config = WAY3_CONFIG_MODE | 1;
+      uint64_t xm = (list_num | (list_num << 16)) | (list_num << 32);
+      INTRINSIC(vmrgsort4,
+                merge_times % 2 ? dst_ptr + base_offset : src_ptr + base_offset,
+                xn,      // the address of each list
+                xm,      // the number of each list
+                config); // config
+    }
+
+    // After sorting, a tail block is formed for the next round of merge
+    merge_remainder->merge_remainder_flag = true;
+    merge_remainder->merge_remainder_num += factor * 3;
+  }
+}
+
+template <typename T>
+__aiv__ __attribute__((always_inline)) void
+merge_sort(memref_t<__ubuf__ T, 1> *src, memref_t<__ubuf__ T, 1> *dst,
+           int64_t real_num, int64_t sort_num, int64_t &merge_times) {
+  auto src_ptr = src->aligned + src->offset;
+  auto dst_ptr = dst->aligned + dst->offset;
+  auto num_per_proposal = PROPOSALS_BYTES / sizeof(T);
+
+  merge_remainder_info merge_remainder;
+  // Whether there is a tail block left in the previous round of merge.
+  merge_remainder.merge_remainder_flag = false;
+  // The number of proposals to be sorted in the tail block left over from the
+  // previous merge round
+  merge_remainder.merge_remainder_num = 0;
+
+  // current merge round number
+  while (1) {
+    int64_t factor = 32 << (merge_times * 2);
+    int64_t quotient_repeat = sort_num / factor / MERGE_SORT_MAX_PROPOSALS_LIST;
+    merge_times++;
+
+    // Processing 4-way merge of main block
+    // The main block requires 4 equal lengths, and the length of each path is
+    // factor(32 << (i * 2))
+    if (quotient_repeat > 0) {
+      INTRINSIC(pipe_barrier, PIPE_V);
+      lower_vms_quotient(src, dst, merge_times, factor, sort_num);
+    }
+
+    // Processing 2/3/4-way merge of tail block
+    INTRINSIC(pipe_barrier, PIPE_V);
+    lower_vms_remainder(src, dst, merge_times, factor, sort_num,
+                        &merge_remainder);
+
+    // merge completion conditions
+    if (quotient_repeat == 0 ||
+        (quotient_repeat == 1 && merge_remainder.merge_remainder_num == 0)) {
+      break;
+    }
+  }
+}
+
+template <typename T>
+__aiv__ __attribute__((always_inline)) void
+move_out_result(memref_t<__ubuf__ T, 1> *src,
+                memref_t<__ubuf__ T, 1> *dst_value,
+                memref_t<__ubuf__ int32_t, 1> *dst_index, bool descending,
+                bool need_index) {
+  // The actual number of data to be sorted
+  int64_t real_num = src->sizes[0];
+
+  auto src_ptr = src->aligned + src->offset;
+  auto dst_value_ptr = dst_value->aligned + dst_value->offset;
+  auto dst_index_ptr = dst_index->aligned + dst_index->offset;
+
+  // Step1: separate dst_value/dst_index from the sorted proposal.
+  INTRINSIC_NO_ARGS(set_mask_count);
+  INTRINSIC(set_vector_mask, 0, real_num);
+  if constexpr (sizeof(T) == 4) {
+    vreducev2_1d_with_pattern_mode<T, PatternMode::INDEX_0_FROM_2_ELEMENTS>(
+        src, dst_value);
+  } else if constexpr (sizeof(T) == 2) {
+    vreducev2_1d_with_pattern_mode<T, PatternMode::INDEX_0_FROM_4_ELEMENTS>(
+        src, dst_value);
+  }
+  if (need_index) {
+    memref_t<__ubuf__ int32_t, 1> src_int32;
+    view_as<T, int32_t, 1>(src, &src_int32);
+    vreducev2_1d_with_pattern_mode<int32_t,
+                                   PatternMode::INDEX_1_FROM_2_ELEMENTS>(
+        &src_int32, dst_index);
+  }
+  INTRINSIC_NO_ARGS(set_mask_norm);
+
+  // Step2: If it is in ascending order, the data needs to be reversed to return
+  // to the original data.
+  if (!descending) {
+    INTRINSIC(pipe_barrier, PIPE_V);
+    if constexpr (sizeof(T) == 4) {
+      memref_t<__ubuf__ int32_t, 1> dst_value_s32;
+      view_as<T, int32_t, 1>(dst_value, &dst_value_s32);
+      vector_eltwise_vs_1d<VectorOpTy::VADDS, int32_t>(
+          &dst_value_s32, S32_MIN_VALUE, &dst_value_s32);
+    } else {
+      memref_t<__ubuf__ int16_t, 1> dst_value_s16;
+      view_as<T, int16_t, 1>(dst_value, &dst_value_s16);
+      vector_eltwise_vs_1d<VectorOpTy::VADDS, int16_t>(
+          &dst_value_s16, S16_MIN_VALUE, &dst_value_s16);
+    }
+  }
+}
+
+template <typename T>
+__aiv__ __attribute__((always_inline)) void lower_sort_operation(
+    memref_t<__ubuf__ T, 1> *src, memref_t<__ubuf__ T, 1> *dst_value,
+    memref_t<__ubuf__ int32_t, 1> *dst_index, memref_t<__ubuf__ T, 1> *tmp_buf,
+    bool descending, bool need_index) {
+  // The actual number of data to be sorted
+  int64_t real_num = src->sizes[0];
+  // Calculate the number of data involved in the sort, (vbitsort requires 32
+  // elements to be aligned)
+  int64_t sort_num = CEIL_FACTOR(src->sizes[0], BIT_SORT_NUM_PER_REPEAT);
+
+  if (real_num == 1) {
+    // When the sort axis is 1, no need to sort, move out directly
+    lower_sort_for_last_axis_is_one(src, dst_value, dst_index, need_index);
+    return;
+  }
+
+  // Step1: Prepare src index for vbitsort
+  prepare_src_index(dst_index, real_num, sort_num);
+
+  // Step2: Prepare src value for vbitsort:
+  // 1. Fill the data to be sorted to ensure that the number is a multiple of 32
+  // 2. If it is ascending order, need to reverse the data
+  memref_t<__ubuf__ T, 1> src_inverse{
+      tmp_buf->aligned, tmp_buf->allocated, tmp_buf->offset, {sort_num}, {1}};
+  if (!descending) {
+    tmp_buf->offset = tmp_buf->offset + sort_num;
+  }
+  prepare_src_value(src, &src_inverse, real_num, sort_num, descending);
+
+  // Step3: Vector Bitonic Sorter
+  // VBS32 will combine index with corresponding score after sorting and output
+  // a proposal structure 8B
+  auto num_per_proposal = PROPOSALS_BYTES / sizeof(T);
+  memref_t<__ubuf__ T, 1> tmp_buf_for_block_sort{
+      tmp_buf->aligned,
+      tmp_buf->allocated,
+      tmp_buf->offset,
+      {static_cast<int64_t>(sort_num * num_per_proposal)},
+      {1}};
+  INTRINSIC(pipe_barrier, PIPE_V);
+  block_sort(descending ? src : &src_inverse, dst_index,
+             &tmp_buf_for_block_sort, real_num, sort_num);
+
+  // Step4: Vector Merge Sorter
+  memref_t<__ubuf__ T, 1> tmp_buf_for_merge_sort{
+      tmp_buf->aligned,
+      tmp_buf->allocated,
+      tmp_buf->offset + static_cast<int64_t>(sort_num * num_per_proposal),
+      {static_cast<int64_t>(sort_num * num_per_proposal)},
+      {1}};
+  int64_t merge_times = 0;
+  INTRINSIC(pipe_barrier, PIPE_V);
+  merge_sort(&tmp_buf_for_block_sort, &tmp_buf_for_merge_sort, real_num,
+             sort_num, merge_times);
+
+  INTRINSIC(pipe_barrier, PIPE_V);
+  // Step5: Process proposal data and move it to dst_value/dst_index
+  move_out_result(merge_times % 2 ? &tmp_buf_for_merge_sort
+                                  : &tmp_buf_for_block_sort,
+                  dst_value, dst_index, descending, need_index);
+}
+
+/// Sort src=(a,) with stride[1,], a is the sorting axis returns the sorted
+/// value of dst_value.
+///
+/// constraint:
+/// 1. Make sure the sum of all bufs is less than UB_MAX.
+/// 2. The data type to be sorted only supports half/float.
+/// 3. src id Continuous 1D.
+/// 4. The size of tmp_buf is as follows:
+///    a == 1:
+///        tmp_buf = 0
+///    a != 1:
+///        descending = false:
+///            dtype = half:
+///                tmp_buf > aligned(a, 32) * 11
+///            dtype = float:
+///                tmp_buf > aligned(a, 32) * 6
+///        descending = true:
+///            dtype = half:
+///                tmp_buf > aligned(a, 32) * 10
+///            dtype = float:
+///                tmp_buf > aligned(a, 32) * 5
+///
+/// \param:
+/// descending: descending = true to sort in descending order, descending =
+/// false to sort in ascending order.
+template <typename T>
+__aiv__ __attribute__((always_inline)) void
+sort_1d(memref_t<__ubuf__ T, 1> *src, memref_t<__ubuf__ T, 1> *dst,
+        bool descending, memref_t<__ubuf__ T, 1> *tmp_buf) {
+  check_inputs_of_sort_1d_with_index(src, dst);
+
+  static_assert(
+      (std::is_same<T, half>::value || std::is_same<T, float>::value) &&
+      "Sort unsupport this type");
+
+  // Calculate the number of data involved in the sort, (vbitsort requires 32
+  // elements to be aligned)
+  int64_t sort_num = CEIL_FACTOR(src->sizes[0], BIT_SORT_NUM_PER_REPEAT);
+
+  // When sorting, need to sort with index, so need to allocate a space in
+  // tmp_buf to store the index corresponding to src_value
+  memref_t<__ubuf__ int32_t, 1> tmp_buf_int32;
+  view_as<T, int32_t, 1>(tmp_buf, &tmp_buf_int32);
+  memref_t<__ubuf__ int32_t, 1> dst_index{tmp_buf_int32.aligned,
+                                          tmp_buf_int32.allocated,
+                                          tmp_buf_int32.offset,
+                                          {sort_num},
+                                          {1}};
+  tmp_buf->offset += sort_num * (sizeof(int32_t) / sizeof(T));
+  lower_sort_operation(src, dst, &dst_index, tmp_buf, descending, false);
+}
+
+/// Sort src=(a,) with stride[1,], a is the sorting axis returns the sorted
+/// value of dst_value and the index corresponding to the dst_value.
+///
+/// constraint:
+/// 1. Make sure the sum of all bufs is less than UB_MAX.
+/// 2. The data type to be sorted only supports half/float.
+/// 3. src id Continuous 1D.
+/// 4. The size of tmp_buf is as follows:
+///    a == 1:
+///        tmp_buf = 0
+///    a != 1:
+///        descending = false:
+///            dtype = half:
+///                tmp_buf > aligned(a, 32) * 9
+///            dtype = float:
+///                tmp_buf > aligned(a, 32) * 5
+///        descending = true:
+///            dtype = half:
+///                tmp_buf > aligned(a, 32) * 8
+///            dtype = float:
+///                tmp_buf > aligned(a, 32) * 4
+///
+/// \param:
+/// descending: descending = true to sort in descending order, descending =
+/// false to sort in ascending order.
+template <typename T>
+__aiv__ __attribute__((always_inline)) void
+sort_1d_with_index(memref_t<__ubuf__ T, 1> *src,
+                   memref_t<__ubuf__ T, 1> *dst_value,
+                   memref_t<__ubuf__ int32_t, 1> *dst_index, bool descending,
+                   memref_t<__ubuf__ T, 1> *tmp_buf) {
+  check_inputs_of_sort_1d_with_index(src, dst_value, dst_index);
+
+  static_assert(
+      (std::is_same<T, half>::value || std::is_same<T, float>::value) &&
+      "Sort unsupport this type");
+  lower_sort_operation(src, dst_value, dst_index, tmp_buf, descending, true);
+}
+
+extern "C" {
+
+/// sort_1d_topk_proposals for float32
+///
+/// Sorts src in descending order, keeps only the top-K proposals in raw
+/// proposal format (interleaved [value, index] as float32 pairs), skipping
+/// the final unpack (vreducev2) step entirely.
+///
+/// The output dst_proposals can be directly passed to merge_sort for
+/// multi-way merging across tiles, saving the cost of unpacking and
+/// re-packing.
+///
+/// Proposal layout (float32): [val0, idx0_as_f32, val1, idx1_as_f32, ...]
+///   - Each proposal occupies 2 x float32 = 8 bytes (PROPOSALS_BYTES)
+///   - idx is stored as reinterpret_cast<float>(int32_t index)
+///
+/// \param src:            tensor<N x f32>         — input values to sort
+/// \param dst_proposals:  tensor<topk*2 x f32>   — output top-K proposals
+/// (packed)
+/// \param descending:     sort direction (true = descending)
+/// \param topk:           number of top elements to retain
+/// \param tmp_buf:        scratch buffer, size >= aligned(N,32) * 5
+/// (descending)
+///                        or aligned(N,32) * 6 (ascending)
+__aiv__ __attribute__((always_inline)) void
+sort_base_impl(memref_t<__ubuf__ float, 1> *src,
+               memref_t<__ubuf__ float, 1> *tmp_buf, bool descending,
+               int64_t topk, int64_t index_offset,
+               memref_t<__ubuf__ float, 1> *dst_proposals) {
+
+  int64_t real_num = src->sizes[0];
+  int64_t sort_num = CEIL_FACTOR(real_num, BIT_SORT_NUM_PER_REPEAT);
+  auto num_per_proposal = PROPOSALS_BYTES / sizeof(float); // == 2
+
+  // ═══════════════════════════════════════════════════════════════════════
+  // Memory layout optimization: reuse src_index space for proposals_b
+  //
+  // Observation: src_index is only needed during block_sort (Step3).
+  // After block_sort completes, src_index is dead — its content has been
+  // packed into the proposal format by vbitsort. proposals_b is only
+  // needed during merge_sort (Step4). So we can overlap them.
+  //
+  // Layout (descending, float32):
+  //   tmp_buf[0 .. sort_num*2):           proposals_a  (block_sort output)
+  //   tmp_buf[sort_num*2 .. sort_num*4):  proposals_b  (merge_sort ping-pong)
+  //     └── tmp_buf[sort_num*2 .. sort_num*3): also used as src_index
+  //         (safe: src_index is consumed before merge_sort overwrites it)
+  //
+  // Layout (ascending, float32):
+  //   tmp_buf[0 .. sort_num):             src_inverse  (flipped values)
+  //   tmp_buf[sort_num .. sort_num*3):    proposals_a
+  //   tmp_buf[sort_num*3 .. sort_num*5):  proposals_b
+  //     └── tmp_buf[sort_num*3 .. sort_num*4): also used as src_index
+  //
+  // Total: descending = sort_num * 4, ascending = sort_num * 5
+  // ═══════════════════════════════════════════════════════════════════════
+
+  // --- Compute offsets ---
+  int64_t base = tmp_buf->offset;
+  int64_t proposals_a_offset;
+  int64_t proposals_b_offset;
+  int64_t src_index_offset;
+
+  if (descending) {
+    // [0, sort_num*2): proposals_a
+    // [sort_num*2, sort_num*4): proposals_b (front part reused as src_index)
+    proposals_a_offset = base;
+    proposals_b_offset = base + sort_num * num_per_proposal;
+    src_index_offset = proposals_b_offset; // reuse proposals_b's front
+  } else {
+    // [0, sort_num): src_inverse
+    // [sort_num, sort_num*3): proposals_a
+    // [sort_num*3, sort_num*5): proposals_b (front part reused as src_index)
+    proposals_a_offset = base + sort_num;
+    proposals_b_offset = base + sort_num + sort_num * num_per_proposal;
+    src_index_offset = proposals_b_offset; // reuse proposals_b's front
+  }
+
+  // --- Step1: Prepare index (arange) — placed at proposals_b's start ---
+  memref_t<__ubuf__ int32_t, 1> tmp_buf_int32;
+  view_as<float, int32_t, 1>(tmp_buf, &tmp_buf_int32);
+  // src_index_offset is in float32 units, same as int32 units for float
+  memref_t<__ubuf__ int32_t, 1> src_index{tmp_buf_int32.aligned,
+                                          tmp_buf_int32.allocated,
+                                          src_index_offset,
+                                          {sort_num},
+                                          {1}};
+
+  prepare_src_index(&src_index, real_num, sort_num, index_offset);
+
+  // --- Step2: Prepare src value (pad + flip for ascending) ---
+  if (!descending) {
+    memref_t<__ubuf__ float, 1> src_inverse{
+        tmp_buf->aligned, tmp_buf->allocated, base, {sort_num}, {1}};
+    prepare_src_value(src, &src_inverse, real_num, sort_num, descending);
+
+    // --- Step3: Block sort (vbitsort) → proposal format ---
+    memref_t<__ubuf__ float, 1> proposals_a{
+        tmp_buf->aligned,
+        tmp_buf->allocated,
+        proposals_a_offset,
+        {static_cast<int64_t>(sort_num * num_per_proposal)},
+        {1}};
+    INTRINSIC(pipe_barrier, PIPE_V);
+    block_sort(&src_inverse, &src_index, &proposals_a, real_num, sort_num);
+
+    // --- Step4: Merge sort (vmrgsort4) ---
+    // After block_sort, src_index is dead. proposals_b can now safely use
+    // the same memory region.
+    memref_t<__ubuf__ float, 1> proposals_b{
+        tmp_buf->aligned,
+        tmp_buf->allocated,
+        proposals_b_offset,
+        {static_cast<int64_t>(sort_num * num_per_proposal)},
+        {1}};
+    int64_t merge_times = 0;
+    INTRINSIC(pipe_barrier, PIPE_V);
+    merge_sort(&proposals_a, &proposals_b, real_num, sort_num, merge_times);
+
+    // --- Step5: Truncate top-K proposals → dst_proposals (NO unpack) ---
+    INTRINSIC(pipe_barrier, PIPE_V);
+    int64_t copy_size = topk * num_per_proposal;
+    memref_t<__ubuf__ float, 1> src_slice{
+        (merge_times % 2) ? proposals_b.aligned : proposals_a.aligned,
+        (merge_times % 2) ? proposals_b.allocated : proposals_a.allocated,
+        (merge_times % 2) ? proposals_b.offset : proposals_a.offset,
+        {copy_size},
+        {1}};
+    memref_t<__ubuf__ float, 1> dst_slice{dst_proposals->aligned,
+                                          dst_proposals->allocated,
+                                          dst_proposals->offset,
+                                          {copy_size},
+                                          {1}};
+    copy_ubuf_to_ubuf_1d_core(&src_slice, &dst_slice);
+  } else {
+    // descending: no src_inverse needed, block_sort reads src directly
+    prepare_src_value(src, src, real_num, sort_num, descending);
+
+    // --- Step3: Block sort (vbitsort) → proposal format ---
+    memref_t<__ubuf__ float, 1> proposals_a{
+        tmp_buf->aligned,
+        tmp_buf->allocated,
+        proposals_a_offset,
+        {static_cast<int64_t>(sort_num * num_per_proposal)},
+        {1}};
+    INTRINSIC(pipe_barrier, PIPE_V);
+    block_sort(src, &src_index, &proposals_a, real_num, sort_num);
+
+    // --- Step4: Merge sort (vmrgsort4) ---
+    // After block_sort, src_index is dead. proposals_b can now safely use
+    // the same memory region.
+    memref_t<__ubuf__ float, 1> proposals_b{
+        tmp_buf->aligned,
+        tmp_buf->allocated,
+        proposals_b_offset,
+        {static_cast<int64_t>(sort_num * num_per_proposal)},
+        {1}};
+    int64_t merge_times = 0;
+    INTRINSIC(pipe_barrier, PIPE_V);
+    merge_sort(&proposals_a, &proposals_b, real_num, sort_num, merge_times);
+
+    // --- Step5: Truncate top-K proposals → dst_proposals (NO unpack) ---
+    INTRINSIC(pipe_barrier, PIPE_V);
+    int64_t copy_size = topk * num_per_proposal;
+    memref_t<__ubuf__ float, 1> src_slice{
+        (merge_times % 2) ? proposals_b.aligned : proposals_a.aligned,
+        (merge_times % 2) ? proposals_b.allocated : proposals_a.allocated,
+        (merge_times % 2) ? proposals_b.offset : proposals_a.offset,
+        {copy_size},
+        {1}};
+    memref_t<__ubuf__ float, 1> dst_slice{dst_proposals->aligned,
+                                          dst_proposals->allocated,
+                                          dst_proposals->offset,
+                                          {copy_size},
+                                          {1}};
+    copy_ubuf_to_ubuf_1d_core(&src_slice, &dst_slice);
+  }
+}
+
+} // extern "C"

--- a/python/triton/experimental/tle/language/dsa/ascend/custom_ops/sort_ops/sort_common.h
+++ b/python/triton/experimental/tle/language/dsa/ascend/custom_ops/sort_ops/sort_common.h
@@ -1,0 +1,73 @@
+// Copyright 2026- Xcoresigma Technology Co., Ltd
+
+// Shared vmrgsort4 / proposal helpers, included by the other sort_ops files.
+
+#pragma once
+
+#include "Vector/Cast/CastUtils.h"
+#include "Vector/Sort/SortUtils.h"
+#include "Vector/VecUtils.h"
+
+// Exhaustion mode: config[12] = isAllStored = 1
+constexpr uint64_t VMRG4_EXHAUST_BIT = (uint64_t)1 << 12;
+
+// Read VMS4_SR (per-way consumed counts, packed in 16-bit fields).
+// See get_vms4_sr at intrisics.h #2028.
+static inline __aiv__ __attribute__((always_inline)) uint64_t read_vms4_sr() {
+  return (uint64_t)get_vms4_sr();
+}
+
+// Extract the consumed proposal count of way i (0..3) from the packed register
+static inline __aiv__ __attribute__((always_inline)) uint32_t
+vms4_consumed(uint64_t sr, int i) {
+  return (uint32_t)((sr >> (16 * i)) & 0xFFFF);
+}
+
+// ============================================================================
+// One exhaustion-mode K-way merge (K=2/3/4); returns VMS4_SR.
+//   dst:  start of the output proposals
+//   xn:   array of start pointers of the K input ways
+//   lens: input length of each way (in proposals)
+//   ways: 2/3/4
+// Output length = sum of per-way consumed counts (= the safe prefix emitted
+// until some way is exhausted).
+// ============================================================================
+template <typename T>
+__aiv__ __attribute__((always_inline)) uint64_t vmrgsort4_exhaust(
+    __ubuf__ T *dst, __ubuf__ T **xn, const uint32_t *lens, int ways) {
+  // src1 = per-way lengths packed into 4x16-bit fields (unused ways filled
+  // with 0)
+  uint64_t xm = 0;
+  for (int i = 0; i < ways; ++i)
+    xm |= ((uint64_t)(lens[i] & 0xFFFF)) << (16 * i);
+
+  // maskSignal: `ways` active ways -> low `ways` bits set
+  uint64_t mask = ((1ull << ways) - 1) & 0xF;
+  uint64_t config =
+      (mask << 8) | VMRG4_EXHAUST_BIT | 1; // repeat=1, exhaustion mode
+
+  INTRINSIC(pipe_barrier, PIPE_V);
+  INTRINSIC(vmrgsort4, dst, xn, xm, config);
+
+  // Key point: read back the per-way consumed counts (feedback channel
+  // exclusive to exhaustion mode)
+  return read_vms4_sr();
+}
+
+// Split compact proposals ([value (f32), index (i32 reinterpreted as f32)]
+// pairs) into separate value/index sequences. Extract the index first so it
+// is not clobbered by the value write.
+static inline __aiv__ __attribute__((always_inline)) void
+unpack_proposals(memref_t<__ubuf__ float, 1> *src,
+                 memref_t<__ubuf__ float, 1> *dst_value,
+                 memref_t<__ubuf__ int32_t, 1> *dst_index, int64_t real_num) {
+  INTRINSIC_NO_ARGS(set_mask_count);
+  INTRINSIC(set_vector_mask, 0, real_num);
+  memref_t<__ubuf__ int32_t, 1> src_int32;
+  view_as<float, int32_t, 1>(src, &src_int32);
+  vreducev2_1d_with_pattern_mode<int32_t, PatternMode::INDEX_1_FROM_2_ELEMENTS>(
+      &src_int32, dst_index);
+  vreducev2_1d_with_pattern_mode<float, PatternMode::INDEX_0_FROM_2_ELEMENTS>(
+      src, dst_value);
+  INTRINSIC_NO_ARGS(set_mask_norm);
+}

--- a/python/triton/experimental/tle/language/dsa/ascend/custom_ops/sort_ops/sort_s4096_k129_512.h
+++ b/python/triton/experimental/tle/language/dsa/ascend/custom_ops/sort_ops/sort_s4096_k129_512.h
@@ -1,0 +1,235 @@
+// Copyright 2026- Xcoresigma Technology Co., Ltd
+
+// Included only by custom_ops_aiv.cpp.
+#include "Vector/Arange/ArangeUtils.h"
+#include "Vector/Cast/CastUtils.h"
+#include "Vector/Sort/SortUtils.h"
+#include "Vector/VecUtils.h"
+#include "sort_common.h"
+
+constexpr int64_t CHUNK = 1024;
+constexpr int64_t WAYS = 4;
+constexpr int64_t SMALLK_NPP = PROPOSALS_BYTES / sizeof(float);
+
+__aiv__ __attribute__((always_inline)) void
+prepare_index_smallk(memref_t<__ubuf__ int32_t, 1> *src_index, int64_t real_num,
+                     int64_t sort_num, int64_t index_offset) {
+  src_index->sizes[0] = sort_num;
+  arange_1d(src_index, index_offset, 1);
+  src_index->sizes[0] = real_num;
+}
+
+__aiv__ __attribute__((always_inline)) void
+prepare_desc_value_smallk(memref_t<__ubuf__ float, 1> *src, int64_t real_num,
+                          int64_t sort_num) {
+  auto src_ptr = src->aligned + src->offset;
+  int64_t fill_num = sort_num - real_num;
+  INTRINSIC(set_flag, PIPE_V, PIPE_S, LIB_EVENT_ID0);
+  INTRINSIC(wait_flag, PIPE_V, PIPE_S, LIB_EVENT_ID0);
+  for (int64_t i = 0; i < fill_num; ++i) {
+    *(src_ptr + real_num + i) = static_cast<float>(FLOAT_NEG_INF);
+  }
+  INTRINSIC(set_flag, PIPE_S, PIPE_V, LIB_EVENT_ID0);
+  INTRINSIC(wait_flag, PIPE_S, PIPE_V, LIB_EVENT_ID0);
+}
+
+__aiv__ __attribute__((always_inline)) void
+block_sort_smallk(memref_t<__ubuf__ float, 1> *src_value,
+                  memref_t<__ubuf__ int32_t, 1> *src_index,
+                  memref_t<__ubuf__ float, 1> *dst, int64_t sort_num) {
+  int64_t repeat = sort_num / BIT_SORT_NUM_PER_REPEAT;
+  int64_t sort_num_per_intrinsic =
+      INTR_MAX_REPEAT_CNTS * BIT_SORT_NUM_PER_REPEAT;
+  auto dst_ptr = dst->aligned + dst->offset;
+  auto src_value_ptr = src_value->aligned + src_value->offset;
+  auto src_index_ptr = src_index->aligned + src_index->offset;
+
+  if (repeat >= INTR_MAX_REPEAT_CNTS) {
+    for (int64_t i = 0; i < repeat / INTR_MAX_REPEAT_CNTS; ++i) {
+      INTRINSIC(
+          vbitsort, dst_ptr + i * sort_num_per_intrinsic * SMALLK_NPP,
+          src_value_ptr + i * sort_num_per_intrinsic,
+          (__ubuf__ uint32_t *)(src_index_ptr + i * sort_num_per_intrinsic),
+          INTR_MAX_REPEAT_CNTS);
+    }
+  }
+
+  if (repeat % INTR_MAX_REPEAT_CNTS != 0) {
+    int64_t loop_num = repeat / INTR_MAX_REPEAT_CNTS;
+    INTRINSIC(vbitsort,
+              dst_ptr + loop_num * sort_num_per_intrinsic * SMALLK_NPP,
+              src_value_ptr + loop_num * sort_num_per_intrinsic,
+              (__ubuf__ uint32_t *)(src_index_ptr +
+                                    loop_num * sort_num_per_intrinsic),
+              repeat % INTR_MAX_REPEAT_CNTS);
+  }
+}
+
+__aiv__ __attribute__((always_inline)) void
+merge_sort_1024_smallk(memref_t<__ubuf__ float, 1> *src,
+                       memref_t<__ubuf__ float, 1> *dst) {
+  auto src_ptr = src->aligned + src->offset;
+  auto dst_ptr = dst->aligned + dst->offset;
+
+  // Round 1: thirty-two 32-proposal VBS runs -> eight 128-proposal runs.
+  {
+    __ubuf__ float *xn[4] = {
+        src_ptr,
+        src_ptr + 32 * SMALLK_NPP,
+        src_ptr + 64 * SMALLK_NPP,
+        src_ptr + 96 * SMALLK_NPP,
+    };
+    uint64_t xm = 32 | (32ull << 16) | (32ull << 32) | (32ull << 48);
+    uint64_t config = WAY4_CONFIG_MODE | 8;
+    INTRINSIC(pipe_barrier, PIPE_V);
+    INTRINSIC(vmrgsort4, dst_ptr, xn, xm, config);
+  }
+
+  // Round 2: eight 128-proposal runs -> two 512-proposal runs.
+  {
+    __ubuf__ float *xn[4] = {
+        dst_ptr,
+        dst_ptr + 128 * SMALLK_NPP,
+        dst_ptr + 256 * SMALLK_NPP,
+        dst_ptr + 384 * SMALLK_NPP,
+    };
+    uint64_t xm = 128 | (128ull << 16) | (128ull << 32) | (128ull << 48);
+    uint64_t config = WAY4_CONFIG_MODE | 2;
+    INTRINSIC(pipe_barrier, PIPE_V);
+    INTRINSIC(vmrgsort4, src_ptr, xn, xm, config);
+  }
+
+  // Round 3: two 512-proposal runs -> one 1024-proposal run.
+  {
+    __ubuf__ float *xn[2] = {
+        src_ptr,
+        src_ptr + 512 * SMALLK_NPP,
+    };
+    uint64_t xm = 512 | (512ull << 16);
+    uint64_t config = WAY2_CONFIG_MODE | 1;
+    INTRINSIC(pipe_barrier, PIPE_V);
+    INTRINSIC(vmrgsort4, dst_ptr, xn, xm, config);
+  }
+}
+
+__aiv__ __attribute__((always_inline)) void
+sort_1024_topk_smallk(memref_t<__ubuf__ float, 1> *src,
+                      memref_t<__ubuf__ float, 1> *tmp, int64_t topk,
+                      int64_t index_offset,
+                      memref_t<__ubuf__ float, 1> *dst_proposals) {
+  memref_t<__ubuf__ int32_t, 1> tmp_i32;
+  view_as<float, int32_t, 1>(tmp, &tmp_i32);
+
+  memref_t<__ubuf__ int32_t, 1> src_index{tmp_i32.aligned,
+                                          tmp_i32.allocated,
+                                          tmp_i32.offset + CHUNK * SMALLK_NPP,
+                                          {CHUNK},
+                                          {1}};
+  prepare_index_smallk(&src_index, CHUNK, CHUNK, index_offset);
+  prepare_desc_value_smallk(src, CHUNK, CHUNK);
+
+  memref_t<__ubuf__ float, 1> proposals_a{
+      tmp->aligned, tmp->allocated, tmp->offset, {CHUNK * SMALLK_NPP}, {1}};
+  memref_t<__ubuf__ float, 1> proposals_b{tmp->aligned,
+                                          tmp->allocated,
+                                          tmp->offset + CHUNK * SMALLK_NPP,
+                                          {CHUNK * SMALLK_NPP},
+                                          {1}};
+
+  INTRINSIC(pipe_barrier, PIPE_V);
+  block_sort_smallk(src, &src_index, &proposals_a, CHUNK);
+  INTRINSIC(pipe_barrier, PIPE_V);
+  merge_sort_1024_smallk(&proposals_a, &proposals_b);
+
+  INTRINSIC(pipe_barrier, PIPE_V);
+  memref_t<__ubuf__ float, 1> from{proposals_b.aligned,
+                                   proposals_b.allocated,
+                                   proposals_b.offset,
+                                   {topk * SMALLK_NPP},
+                                   {1}};
+  memref_t<__ubuf__ float, 1> to{dst_proposals->aligned,
+                                 dst_proposals->allocated,
+                                 dst_proposals->offset,
+                                 {topk * SMALLK_NPP},
+                                 {1}};
+  vector_eltwise_vs_1d<VectorOpTy::VADDS, float>(&from, 0.0f, &to);
+}
+
+extern "C" {
+
+/// Small-K segment topk for SEG_LEN=4096.
+///
+/// Split one 4096 segment into 4x1024 sub-runs, sort each sub-run and keep K
+/// candidates, then 4-way merge the four candidate runs and copy only topK
+/// proposals to dst_proposals. This is intended for K <= 1024.
+__aiv__ __attribute__((always_inline)) void
+sort_s4096_k129_512_impl(memref_t<__ubuf__ float, 1> *src,
+                         memref_t<__ubuf__ float, 1> *tmp_buf, bool descending,
+                         int64_t topk, int64_t index_offset,
+                         memref_t<__ubuf__ float, 1> *dst_proposals) {
+  (void)descending;
+
+  int64_t candidates_f32 = WAYS * topk * SMALLK_NPP;
+  int64_t sort_tmp_f32 = CHUNK * SMALLK_NPP * 2;
+  int64_t sort_tmp_base = tmp_buf->offset + candidates_f32;
+  int64_t merge_out_base = sort_tmp_base + sort_tmp_f32;
+
+  for (int64_t lane = 0; lane < WAYS; ++lane) {
+    memref_t<__ubuf__ float, 1> src_chunk{
+        src->aligned, src->allocated, src->offset + lane * CHUNK, {CHUNK}, {1}};
+    memref_t<__ubuf__ float, 1> sort_tmp{tmp_buf->aligned,
+                                         tmp_buf->allocated,
+                                         sort_tmp_base,
+                                         {sort_tmp_f32},
+                                         {1}};
+    memref_t<__ubuf__ float, 1> chunk_dst{tmp_buf->aligned,
+                                          tmp_buf->allocated,
+                                          tmp_buf->offset +
+                                              lane * topk * SMALLK_NPP,
+                                          {topk * SMALLK_NPP},
+                                          {1}};
+    sort_1024_topk_smallk(&src_chunk, &sort_tmp, topk,
+                          index_offset + lane * CHUNK, &chunk_dst);
+  }
+
+  auto tmp_ptr = tmp_buf->aligned + tmp_buf->offset;
+  __ubuf__ float *xn[WAYS] = {
+      tmp_ptr + 0 * topk * SMALLK_NPP,
+      tmp_ptr + 1 * topk * SMALLK_NPP,
+      tmp_ptr + 2 * topk * SMALLK_NPP,
+      tmp_ptr + 3 * topk * SMALLK_NPP,
+  };
+  uint32_t lens[WAYS] = {
+      (uint32_t)topk,
+      (uint32_t)topk,
+      (uint32_t)topk,
+      (uint32_t)topk,
+  };
+
+  __ubuf__ float *merge_out = tmp_buf->aligned + merge_out_base;
+  uint64_t sr = vmrgsort4_exhaust<float>(merge_out, xn, lens, WAYS);
+  int64_t produced = 0;
+  for (int i = 0; i < WAYS; ++i) {
+    produced += (int64_t)vms4_consumed(sr, i);
+  }
+  if (produced < topk) {
+    // Defensive fallback for unexpected data/configuration.  Valid 4xK input
+    // should always produce at least K proposals when K <= 1024.
+    topk = produced;
+  }
+
+  INTRINSIC(pipe_barrier, PIPE_V);
+  memref_t<__ubuf__ float, 1> from{tmp_buf->aligned,
+                                   tmp_buf->allocated,
+                                   merge_out_base,
+                                   {topk * SMALLK_NPP},
+                                   {1}};
+  memref_t<__ubuf__ float, 1> to{dst_proposals->aligned,
+                                 dst_proposals->allocated,
+                                 dst_proposals->offset,
+                                 {topk * SMALLK_NPP},
+                                 {1}};
+  vector_eltwise_vs_1d<VectorOpTy::VADDS, float>(&from, 0.0f, &to);
+}
+
+} // extern "C"

--- a/python/triton/experimental/tle/language/dsa/ascend/custom_ops/sort_ops/sort_s4096_k1_128_k2048.h
+++ b/python/triton/experimental/tle/language/dsa/ascend/custom_ops/sort_ops/sort_s4096_k1_128_k2048.h
@@ -1,0 +1,498 @@
+// Copyright 2026- Xcoresigma Technology Co., Ltd
+
+// Included only by custom_ops_aiv.cpp.
+#include "Vector/Arange/ArangeUtils.h"
+#include "Vector/Cast/CastUtils.h"
+#include "Vector/Sort/SortUtils.h"
+#include "Vector/VecUtils.h"
+#include "sort_common.h"
+
+constexpr int64_t SEG_LEN = 4096;
+constexpr int64_t RUN_LEN = 512;
+constexpr int64_t NUM_RUNS = SEG_LEN / RUN_LEN;
+constexpr int64_t GROUPS = NUM_RUNS / 4;
+constexpr int64_t LAYERED_NPP = PROPOSALS_BYTES / sizeof(float);
+constexpr int64_t PROPS_A_F32 = SEG_LEN * LAYERED_NPP;
+constexpr int64_t PROPS_B_F32 = SEG_LEN * LAYERED_NPP;
+constexpr int64_t GROUP_BUF_PROPS = 4 * RUN_LEN;
+constexpr int64_t GROUP_BUF_F32 = GROUP_BUF_PROPS * LAYERED_NPP;
+constexpr int64_t FINAL_OUT_PROPS = GROUPS * GROUP_BUF_PROPS;
+constexpr int64_t FINAL_OUT_F32 = FINAL_OUT_PROPS * LAYERED_NPP + 8;
+
+__aiv__ __attribute__((always_inline)) void
+copy_ub_float(__ubuf__ float *src, int64_t src_off, __ubuf__ float *dst,
+              int64_t dst_off, int64_t count) {
+  if (count <= 0) {
+    return;
+  }
+  INTRINSIC(pipe_barrier, PIPE_V);
+  memref_t<__ubuf__ float, 1> from{src, src, src_off, {count}, {1}};
+  memref_t<__ubuf__ float, 1> to{dst, dst, dst_off, {count}, {1}};
+  vector_eltwise_vs_1d<VectorOpTy::VADDS, float>(&from, 0.0f, &to);
+}
+
+__aiv__ __attribute__((always_inline)) void
+prepare_index_layered(memref_t<__ubuf__ int32_t, 1> *src_index,
+                      int64_t real_num, int64_t sort_num,
+                      int64_t index_offset) {
+  src_index->sizes[0] = sort_num;
+  arange_1d(src_index, index_offset, 1);
+  src_index->sizes[0] = real_num;
+}
+
+__aiv__ __attribute__((always_inline)) void
+prepare_desc_value_layered(memref_t<__ubuf__ float, 1> *src, int64_t real_num,
+                           int64_t sort_num) {
+  auto src_ptr = src->aligned + src->offset;
+  int64_t fill_num = sort_num - real_num;
+  INTRINSIC(set_flag, PIPE_V, PIPE_S, LIB_EVENT_ID0);
+  INTRINSIC(wait_flag, PIPE_V, PIPE_S, LIB_EVENT_ID0);
+  for (int64_t i = 0; i < fill_num; ++i) {
+    *(src_ptr + real_num + i) = static_cast<float>(FLOAT_NEG_INF);
+  }
+  INTRINSIC(set_flag, PIPE_S, PIPE_V, LIB_EVENT_ID0);
+  INTRINSIC(wait_flag, PIPE_S, PIPE_V, LIB_EVENT_ID0);
+}
+
+__aiv__ __attribute__((always_inline)) void
+block_sort_layered(memref_t<__ubuf__ float, 1> *src_value,
+                   memref_t<__ubuf__ int32_t, 1> *src_index,
+                   memref_t<__ubuf__ float, 1> *dst, int64_t sort_num) {
+  int64_t repeat = sort_num / BIT_SORT_NUM_PER_REPEAT;
+  int64_t sort_num_per_intrinsic =
+      INTR_MAX_REPEAT_CNTS * BIT_SORT_NUM_PER_REPEAT;
+  auto dst_ptr = dst->aligned + dst->offset;
+  auto src_value_ptr = src_value->aligned + src_value->offset;
+  auto src_index_ptr = src_index->aligned + src_index->offset;
+
+  if (repeat >= INTR_MAX_REPEAT_CNTS) {
+    for (int64_t i = 0; i < repeat / INTR_MAX_REPEAT_CNTS; ++i) {
+      INTRINSIC(
+          vbitsort, dst_ptr + i * sort_num_per_intrinsic * LAYERED_NPP,
+          src_value_ptr + i * sort_num_per_intrinsic,
+          (__ubuf__ uint32_t *)(src_index_ptr + i * sort_num_per_intrinsic),
+          INTR_MAX_REPEAT_CNTS);
+    }
+  }
+
+  if (repeat % INTR_MAX_REPEAT_CNTS != 0) {
+    int64_t loop_num = repeat / INTR_MAX_REPEAT_CNTS;
+    INTRINSIC(vbitsort,
+              dst_ptr + loop_num * sort_num_per_intrinsic * LAYERED_NPP,
+              src_value_ptr + loop_num * sort_num_per_intrinsic,
+              (__ubuf__ uint32_t *)(src_index_ptr +
+                                    loop_num * sort_num_per_intrinsic),
+              repeat % INTR_MAX_REPEAT_CNTS);
+  }
+}
+
+__aiv__ __attribute__((always_inline)) void
+merge_stage4_layered(memref_t<__ubuf__ float, 1> *src,
+                     memref_t<__ubuf__ float, 1> *dst, int64_t factor,
+                     int64_t repeat) {
+  auto src_ptr = src->aligned + src->offset;
+  auto dst_ptr = dst->aligned + dst->offset;
+  int64_t list_interval_offset = factor * LAYERED_NPP;
+  uint64_t list_num = factor & (int64_t)MAX_UINT16;
+  __ubuf__ float *xn[4] = {
+      src_ptr,
+      src_ptr + list_interval_offset,
+      src_ptr + list_interval_offset * 2,
+      src_ptr + list_interval_offset * 3,
+  };
+  uint64_t xm =
+      ((list_num | (list_num << 16)) | (list_num << 32)) | (list_num << 48);
+  uint64_t config = WAY4_CONFIG_MODE | (repeat & INTR_MAX_REPEAT_CNTS);
+  INTRINSIC(pipe_barrier, PIPE_V);
+  INTRINSIC(vmrgsort4, dst_ptr, xn, xm, config);
+}
+
+__aiv__ __attribute__((always_inline)) int64_t vms_total_layered(uint64_t sr,
+                                                                 int ways) {
+  int64_t total = 0;
+  for (int i = 0; i < ways; ++i) {
+    total += (int64_t)vms4_consumed(sr, i);
+  }
+  return total;
+}
+
+__aiv__ __attribute__((always_inline)) void
+merge_stage2_layered(memref_t<__ubuf__ float, 1> *src,
+                     memref_t<__ubuf__ float, 1> *dst, int64_t factor,
+                     int64_t repeat) {
+  auto src_ptr = src->aligned + src->offset;
+  auto dst_ptr = dst->aligned + dst->offset;
+  uint64_t list_num = factor & (int64_t)MAX_UINT16;
+  uint64_t xm = list_num | (list_num << 16);
+  uint64_t config = WAY2_CONFIG_MODE | 1;
+  for (int64_t r = 0; r < repeat; ++r) {
+    __ubuf__ float *xn[2] = {
+        src_ptr + (2 * r) * factor * LAYERED_NPP,
+        src_ptr + (2 * r + 1) * factor * LAYERED_NPP,
+    };
+    INTRINSIC(pipe_barrier, PIPE_V);
+    INTRINSIC(vmrgsort4, dst_ptr + (2 * r) * factor * LAYERED_NPP, xn, xm,
+              config);
+  }
+}
+
+__aiv__ __attribute__((always_inline)) void merge_8x512_top512_layered(
+    memref_t<__ubuf__ float, 1> *runs, __ubuf__ float *group0,
+    __ubuf__ float *group1, __ubuf__ float *final_out,
+    memref_t<__ubuf__ float, 1> *dst_proposals, int64_t topk) {
+  auto run_ptr = runs->aligned + runs->offset;
+  __ubuf__ float *group_bufs[2] = {group0, group1};
+  uint32_t group_len[2] = {0, 0};
+
+  for (int g = 0; g < 2; ++g) {
+    __ubuf__ float *xn[4] = {
+        run_ptr + (g * 4 + 0) * RUN_LEN * LAYERED_NPP,
+        run_ptr + (g * 4 + 1) * RUN_LEN * LAYERED_NPP,
+        run_ptr + (g * 4 + 2) * RUN_LEN * LAYERED_NPP,
+        run_ptr + (g * 4 + 3) * RUN_LEN * LAYERED_NPP,
+    };
+    uint32_t lens[4] = {(uint32_t)RUN_LEN, (uint32_t)RUN_LEN, (uint32_t)RUN_LEN,
+                        (uint32_t)RUN_LEN};
+    uint64_t sr = vmrgsort4_exhaust<float>(group_bufs[g], xn, lens, 4);
+    group_len[g] = (uint32_t)vms_total_layered(sr, 4);
+  }
+
+  __ubuf__ float *xn[2] = {group0, group1};
+  uint32_t lens[2] = {group_len[0], group_len[1]};
+  uint64_t sr = vmrgsort4_exhaust<float>(final_out, xn, lens, 2);
+  int64_t produced = vms_total_layered(sr, 2);
+  int64_t copy_props = topk;
+  if (copy_props > produced) {
+    copy_props = produced;
+  }
+  copy_ub_float(final_out, 0, dst_proposals->aligned + dst_proposals->offset, 0,
+                copy_props * LAYERED_NPP);
+}
+
+__aiv__ __attribute__((always_inline)) void merge_4x1024_top1024_layered(
+    memref_t<__ubuf__ float, 1> *runs1024, __ubuf__ float *final_out,
+    memref_t<__ubuf__ float, 1> *dst_proposals, int64_t topk) {
+  auto run_ptr = runs1024->aligned + runs1024->offset;
+  __ubuf__ float *xn[4] = {
+      run_ptr + 0 * 1024 * LAYERED_NPP,
+      run_ptr + 1 * 1024 * LAYERED_NPP,
+      run_ptr + 2 * 1024 * LAYERED_NPP,
+      run_ptr + 3 * 1024 * LAYERED_NPP,
+  };
+  uint32_t lens[4] = {1024, 1024, 1024, 1024};
+  uint64_t sr = vmrgsort4_exhaust<float>(final_out, xn, lens, 4);
+  int64_t produced = vms_total_layered(sr, 4);
+  int64_t copy_props = topk;
+  if (copy_props > produced) {
+    copy_props = produced;
+  }
+  copy_ub_float(final_out, 0, dst_proposals->aligned + dst_proposals->offset, 0,
+                copy_props * LAYERED_NPP);
+}
+
+__aiv__ __attribute__((always_inline)) void
+merge_groups_topk_layered(__ubuf__ float *src, int64_t src_run_len,
+                          int64_t num_runs, __ubuf__ float *dst,
+                          int64_t dst_run_len, __ubuf__ float *scratch) {
+  int64_t out_run = 0;
+  for (int64_t base_run = 0; base_run < num_runs; base_run += 4) {
+    __ubuf__ float *xn[4];
+    uint32_t lens[4] = {0, 0, 0, 0};
+    int active = 0;
+    for (int i = 0; i < 4; ++i) {
+      int64_t run = base_run + i;
+      if (run >= num_runs) {
+        break;
+      }
+      xn[active] = src + run * src_run_len * LAYERED_NPP;
+      lens[active] = (uint32_t)src_run_len;
+      active++;
+    }
+
+    if (active == 1) {
+      copy_ub_float(src, base_run * src_run_len * LAYERED_NPP, dst,
+                    out_run * dst_run_len * LAYERED_NPP,
+                    dst_run_len * LAYERED_NPP);
+      out_run++;
+      continue;
+    }
+
+    uint64_t sr = vmrgsort4_exhaust<float>(scratch, xn, lens, active);
+    int64_t produced = vms_total_layered(sr, active);
+    int64_t copy_props = dst_run_len;
+    if (copy_props > produced) {
+      copy_props = produced;
+    }
+    copy_ub_float(scratch, 0, dst, out_run * dst_run_len * LAYERED_NPP,
+                  copy_props * LAYERED_NPP);
+    out_run++;
+  }
+}
+
+__aiv__ __attribute__((always_inline)) void
+final_merge_runs_topk_layered(__ubuf__ float *src, int64_t run_len,
+                              int64_t num_runs, __ubuf__ float *scratch,
+                              memref_t<__ubuf__ float, 1> *dst_proposals,
+                              int64_t topk) {
+  if (num_runs <= 1) {
+    copy_ub_float(src, 0, dst_proposals->aligned + dst_proposals->offset, 0,
+                  topk * LAYERED_NPP);
+    return;
+  }
+
+  __ubuf__ float *xn[4];
+  uint32_t lens[4] = {0, 0, 0, 0};
+  int active = 0;
+  for (int64_t run = 0; run < num_runs && run < 4; ++run) {
+    xn[active] = src + run * run_len * LAYERED_NPP;
+    lens[active] = (uint32_t)run_len;
+    active++;
+  }
+  uint64_t sr = vmrgsort4_exhaust<float>(scratch, xn, lens, active);
+  int64_t produced = vms_total_layered(sr, active);
+  int64_t copy_props = topk;
+  if (copy_props > produced) {
+    copy_props = produced;
+  }
+  copy_ub_float(scratch, 0, dst_proposals->aligned + dst_proposals->offset, 0,
+                copy_props * LAYERED_NPP);
+}
+
+__aiv__ __attribute__((always_inline)) void merge_128x32_top32_layered(
+    memref_t<__ubuf__ float, 1> *runs32, memref_t<__ubuf__ float, 1> *tmp_runs,
+    __ubuf__ float *scratch, memref_t<__ubuf__ float, 1> *dst_proposals,
+    int64_t topk) {
+  auto a = runs32->aligned + runs32->offset;
+  auto b = tmp_runs->aligned + tmp_runs->offset;
+  merge_groups_topk_layered(a, 32, 128, b, 32, scratch); // 128 -> 32
+  merge_groups_topk_layered(b, 32, 32, a, 32, scratch);  // 32 -> 8
+  merge_groups_topk_layered(a, 32, 8, b, 32, scratch);   // 8 -> 2
+  final_merge_runs_topk_layered(b, 32, 2, scratch, dst_proposals, topk);
+}
+
+__aiv__ __attribute__((always_inline)) void merge_32x128_top128_layered(
+    memref_t<__ubuf__ float, 1> *runs128, memref_t<__ubuf__ float, 1> *tmp_runs,
+    __ubuf__ float *scratch, memref_t<__ubuf__ float, 1> *dst_proposals,
+    int64_t topk) {
+  auto a = runs128->aligned + runs128->offset;
+  auto b = tmp_runs->aligned + tmp_runs->offset;
+  merge_groups_topk_layered(a, 128, 32, b, 128, scratch); // 32 -> 8
+  merge_groups_topk_layered(b, 128, 8, a, 128, scratch);  // 8 -> 2
+  final_merge_runs_topk_layered(a, 128, 2, scratch, dst_proposals, topk);
+}
+
+__aiv__ __attribute__((always_inline)) int64_t
+refill_group_layered(memref_t<__ubuf__ float, 1> *runs, int64_t group_id,
+                     int64_t *raw_cursor, __ubuf__ float *group_buf) {
+  auto run_ptr = runs->aligned + runs->offset;
+  __ubuf__ float *xn[4];
+  uint32_t lens[4] = {0, 0, 0, 0};
+  int orig_idx[4] = {0, 0, 0, 0};
+  int active = 0;
+
+  int64_t base_run = group_id * 4;
+  for (int i = 0; i < 4; ++i) {
+    int64_t run = base_run + i;
+    int64_t remain = RUN_LEN - raw_cursor[run];
+    if (remain <= 0) {
+      continue;
+    }
+    xn[active] = run_ptr + (run * RUN_LEN + raw_cursor[run]) * LAYERED_NPP;
+    lens[active] = (uint32_t)remain;
+    orig_idx[active] = i;
+    active++;
+  }
+
+  if (active == 0) {
+    return 0;
+  }
+
+  if (active == 1) {
+    int64_t run = base_run + orig_idx[0];
+    int64_t take = RUN_LEN - raw_cursor[run];
+    copy_ub_float(run_ptr, (run * RUN_LEN + raw_cursor[run]) * LAYERED_NPP,
+                  group_buf, 0, take * LAYERED_NPP);
+    raw_cursor[run] += take;
+    return take;
+  }
+
+  uint64_t sr = vmrgsort4_exhaust<float>(group_buf, xn, lens, active);
+  int64_t produced = 0;
+  for (int w = 0; w < active; ++w) {
+    int64_t consumed = (int64_t)vms4_consumed(sr, w);
+    int64_t run = base_run + orig_idx[w];
+    raw_cursor[run] += consumed;
+    produced += consumed;
+  }
+  return produced;
+}
+
+__aiv__ __attribute__((always_inline)) void merge_8x512_topk_layered(
+    memref_t<__ubuf__ float, 1> *runs, __ubuf__ float *group0,
+    __ubuf__ float *group1, __ubuf__ float *final_out,
+    memref_t<__ubuf__ float, 1> *dst_proposals, int64_t topk) {
+  __ubuf__ float *group_bufs[2] = {group0, group1};
+  int64_t raw_cursor[NUM_RUNS];
+  int64_t group_pos[GROUPS] = {0, 0};
+  int64_t group_len[GROUPS] = {0, 0};
+  for (int i = 0; i < NUM_RUNS; ++i) {
+    raw_cursor[i] = 0;
+  }
+
+  for (int g = 0; g < GROUPS; ++g) {
+    group_len[g] = refill_group_layered(runs, g, raw_cursor, group_bufs[g]);
+    group_pos[g] = 0;
+  }
+
+  auto dst_ptr = dst_proposals->aligned + dst_proposals->offset;
+  int64_t produced_total = 0;
+  while (produced_total < topk) {
+    for (int g = 0; g < GROUPS; ++g) {
+      if (group_pos[g] >= group_len[g]) {
+        group_len[g] = refill_group_layered(runs, g, raw_cursor, group_bufs[g]);
+        group_pos[g] = 0;
+      }
+    }
+
+    __ubuf__ float *xn[2];
+    uint32_t lens[2] = {0, 0};
+    int orig_idx[2] = {0, 0};
+    int active = 0;
+    for (int g = 0; g < GROUPS; ++g) {
+      int64_t remain = group_len[g] - group_pos[g];
+      if (remain <= 0) {
+        continue;
+      }
+      xn[active] = group_bufs[g] + group_pos[g] * LAYERED_NPP;
+      lens[active] = (uint32_t)remain;
+      orig_idx[active] = g;
+      active++;
+    }
+
+    if (active == 0) {
+      break;
+    }
+
+    if (active == 1) {
+      int g = orig_idx[0];
+      int64_t take = group_len[g] - group_pos[g];
+      if (produced_total + take > topk) {
+        take = topk - produced_total;
+      }
+      copy_ub_float(group_bufs[g], group_pos[g] * LAYERED_NPP, dst_ptr,
+                    produced_total * LAYERED_NPP, take * LAYERED_NPP);
+      group_pos[g] += take;
+      produced_total += take;
+      continue;
+    }
+
+    uint64_t sr = vmrgsort4_exhaust<float>(final_out, xn, lens, active);
+    int64_t batch = 0;
+    int64_t consumed_by_group[GROUPS] = {0, 0};
+    for (int w = 0; w < active; ++w) {
+      int64_t consumed = (int64_t)vms4_consumed(sr, w);
+      consumed_by_group[orig_idx[w]] = consumed;
+      batch += consumed;
+    }
+
+    if (batch <= 0) {
+      break;
+    }
+
+    int64_t copy_props = batch;
+    if (produced_total + copy_props > topk) {
+      copy_props = topk - produced_total;
+    }
+    copy_ub_float(final_out, 0, dst_ptr, produced_total * LAYERED_NPP,
+                  copy_props * LAYERED_NPP);
+
+    for (int g = 0; g < GROUPS; ++g) {
+      group_pos[g] += consumed_by_group[g];
+    }
+    produced_total += copy_props;
+  }
+}
+
+extern "C" {
+
+/// Layered TopK sort for one 4096-f32 segment.
+///
+/// The normal custom_sort fully merges 4096 proposals, then copies topK.  This
+/// variant stops after building eight sorted 512-proposal runs and streams a
+/// truncated merge from those runs.  It is intended for K <= 1024.
+__aiv__ __attribute__((always_inline)) void sort_s4096_k1_128_k2048_impl(
+    memref_t<__ubuf__ float, 1> *src, memref_t<__ubuf__ float, 1> *tmp_buf,
+    bool descending, int64_t topk, int64_t index_offset,
+    memref_t<__ubuf__ float, 1> *dst_proposals) {
+  (void)descending;
+
+  int64_t real_num = src->sizes[0];
+  int64_t sort_num = SEG_LEN;
+  if (topk > 2048) {
+    topk = 2048;
+  }
+
+  int64_t base = tmp_buf->offset;
+  int64_t proposals_a_offset = base;
+  int64_t proposals_b_offset = base + PROPS_A_F32;
+  int64_t group0_offset = proposals_b_offset + PROPS_B_F32;
+  int64_t group1_offset = group0_offset + GROUP_BUF_F32;
+  int64_t final_out_offset = group1_offset + GROUP_BUF_F32;
+
+  memref_t<__ubuf__ float, 1> proposals_a{tmp_buf->aligned,
+                                          tmp_buf->allocated,
+                                          proposals_a_offset,
+                                          {PROPS_A_F32},
+                                          {1}};
+  memref_t<__ubuf__ float, 1> proposals_b{tmp_buf->aligned,
+                                          tmp_buf->allocated,
+                                          proposals_b_offset,
+                                          {PROPS_B_F32},
+                                          {1}};
+
+  memref_t<__ubuf__ int32_t, 1> tmp_i32;
+  view_as<float, int32_t, 1>(tmp_buf, &tmp_i32);
+  memref_t<__ubuf__ int32_t, 1> src_index{
+      tmp_i32.aligned, tmp_i32.allocated, proposals_b_offset, {SEG_LEN}, {1}};
+
+  prepare_index_layered(&src_index, real_num, sort_num, index_offset);
+  prepare_desc_value_layered(src, real_num, sort_num);
+
+  INTRINSIC(pipe_barrier, PIPE_V);
+  block_sort_layered(src, &src_index, &proposals_a, sort_num);
+
+  __ubuf__ float *group0 = tmp_buf->aligned + group0_offset;
+  __ubuf__ float *group1 = tmp_buf->aligned + group1_offset;
+  __ubuf__ float *final_out = tmp_buf->aligned + final_out_offset;
+
+  if (topk <= 32) {
+    merge_128x32_top32_layered(&proposals_a, &proposals_b, final_out,
+                               dst_proposals, topk);
+    return;
+  }
+
+  // 128x32 VBS runs -> 32x128 runs.
+  merge_stage4_layered(&proposals_a, &proposals_b, 32, 32);
+
+  if (topk <= 128) {
+    merge_32x128_top128_layered(&proposals_b, &proposals_a, final_out,
+                                dst_proposals, topk);
+    return;
+  }
+
+  // 32x128 runs -> 8x512 runs.
+  merge_stage4_layered(&proposals_b, &proposals_a, 128, 8);
+
+  if (topk <= 512) {
+    merge_8x512_top512_layered(&proposals_a, group0, group1, final_out,
+                               dst_proposals, topk);
+  } else {
+    // 8x512 -> 2x2048, then one truncated 2-way merge.  TopK<=2048 can never
+    // need more than 2048 proposals from either 4-run group.
+    merge_stage4_layered(&proposals_a, &proposals_b, 512, 2);
+    final_merge_runs_topk_layered(proposals_b.aligned + proposals_b.offset,
+                                  2048, 2, final_out, dst_proposals, topk);
+  }
+}
+
+} // extern "C"

--- a/python/triton/experimental/tle/language/dsa/ascend/custom_ops/sort_ops/unpack_sort.cpp
+++ b/python/triton/experimental/tle/language/dsa/ascend/custom_ops/sort_ops/unpack_sort.cpp
@@ -1,0 +1,39 @@
+// Copyright 2026- Xcoresigma Technology Co., Ltd
+
+// Compiled standalone (AIV/Vector) into its own bitcode.
+#include "sort_common.h"
+
+extern "C" {
+
+/// unpack: the first topk proposals -> value/index (for the final output)
+///
+/// Note: the function returns void; outputs are written back through the
+/// dst_value / dst_index pointers.
+/// src_proposals: [in]  the first topk sorted proposals
+/// topk:          [in]  K
+/// dst_value:     [out, written via pointer] tensor<topk x f32>
+/// dst_index:     [out, written via pointer] tensor<topk x i32>
+__aiv__ __attribute__((always_inline)) void
+_mlir_ciface_custom_unpack_sort_float(
+    memref_t<__ubuf__ float, 1> *src_proposals, int64_t topk,
+    memref_t<__ubuf__ float, 1> *dst_value,
+    memref_t<__ubuf__ int32_t, 1> *dst_index) {
+  constexpr int64_t npp = PROPOSALS_BYTES / sizeof(float); // 2
+  // CRITICAL: vreducev2_1d_with_pattern_mode uses src->sizes[0] to set mask,
+  // NOT the topk parameter. If src buffer is larger than topk*npp (which it
+  // always is — it's the full UNPACK_CHUNK*2 buffer), vreducev2 will process
+  // garbage past the valid data and may trigger "illegal configurations".
+  // Solution: create a src view limited to exactly topk*npp elements.
+  memref_t<__ubuf__ float, 1> src_view{src_proposals->aligned,
+                                       src_proposals->allocated,
+                                       src_proposals->offset,
+                                       {topk * npp},
+                                       {1}};
+  memref_t<__ubuf__ float, 1> dval{
+      dst_value->aligned, dst_value->allocated, dst_value->offset, {topk}, {1}};
+  memref_t<__ubuf__ int32_t, 1> didx{
+      dst_index->aligned, dst_index->allocated, dst_index->offset, {topk}, {1}};
+  unpack_proposals(&src_view, &dval, &didx, topk);
+}
+
+} // extern "C"

--- a/python/tutorials/tle/custom/test_custom_ops.py
+++ b/python/tutorials/tle/custom/test_custom_ops.py
@@ -1,0 +1,443 @@
+# Copyright 2026- Xcoresigma Technology Co., Ltd
+"""
+Ascend custom op per-op correctness tests
+===================================================
+
+Minimal standalone correctness checks for every op registered in
+custom_ops.bc, one group per op:
+
+  - gather_gm_to_l1      (fp16 / bf16): verified through a following tl.dot
+  - gather_gm_to_ub      (fp16 / bf16): verified by storing the result to GM
+  - sort_1d_pack         (all three sort paths BASE / S4096_K129_512 /
+                          S4096_K1_128_K2048, plus an index_offset case)
+  - merge_exhaust_sort4  (4-way / 2-way / 3-way with a hole way)
+  - unpack_sort          (split proposals into value / index)
+
+Correctness only, no benchmarking.
+"""
+
+import numpy as np
+import torch
+import torch_npu
+import triton
+import triton.experimental.tle as tle
+import triton.language as tl
+from triton.experimental.tle.language.dsa.ascend.custom_ops import (
+    SORT_IMPL_BASE,
+    SORT_IMPL_S4096_K129_512,
+    SORT_IMPL_S4096_K1_128_K2048,
+)
+
+DEVICE = "npu"
+
+SMALLK_SORT_CHUNK = 1024
+SMALLK_SORT_WAYS = 4
+
+# ══════════════════════════════════════════════════════════════════════════
+# Kernels
+# ══════════════════════════════════════════════════════════════════════════
+
+
+@triton.jit
+def gather_gm_to_l1_dot_kernel(
+    src,
+    src_index,
+    query,
+    output,
+    NUM_ROWS: tl.constexpr,
+    TILE_SIZE: tl.constexpr,
+    D: tl.constexpr,
+    DTYPE: tl.constexpr,
+):
+    src_2d = tl.make_block_ptr(
+        base=src,
+        shape=(NUM_ROWS, D),
+        strides=(D, 1),
+        offsets=(0, 0),
+        block_shape=(TILE_SIZE, D),
+        order=(1, 0),
+    )
+    src_index_2d = tl.make_block_ptr(
+        base=src_index,
+        shape=(TILE_SIZE, 1),
+        strides=(1, 1),
+        offsets=(0, 0),
+        block_shape=(TILE_SIZE, 1),
+        order=(1, 0),
+    )
+    tile_k = tl.full((TILE_SIZE, D), 0, DTYPE)
+    tile_k = tle.dsa.ascend.raw(
+        "gather_gm_to_l1",
+        src_2d,
+        src_index_2d,
+        TILE_SIZE,
+        D,
+        out=tile_k,
+    )
+
+    query_2d = tl.make_block_ptr(
+        base=query,
+        shape=(TILE_SIZE, D),
+        strides=(D, 1),
+        offsets=(0, 0),
+        block_shape=(TILE_SIZE, D),
+        order=(1, 0),
+    )
+    tile_q = tl.load(query_2d)
+    result = tl.dot(tile_q, tl.trans(tile_k))
+
+    output_2d = tl.make_block_ptr(
+        base=output,
+        shape=(TILE_SIZE, TILE_SIZE),
+        strides=(TILE_SIZE, 1),
+        offsets=(0, 0),
+        block_shape=(TILE_SIZE, TILE_SIZE),
+        order=(1, 0),
+    )
+    tl.store(output_2d, result)
+
+
+@triton.jit
+def gather_gm_to_ub_store_kernel(
+    src,
+    src_index,
+    output,
+    NUM_ROWS: tl.constexpr,
+    TILE_SIZE: tl.constexpr,
+    D: tl.constexpr,
+    DTYPE: tl.constexpr,
+):
+    src_2d = tl.make_block_ptr(
+        base=src,
+        shape=(NUM_ROWS, D),
+        strides=(D, 1),
+        offsets=(0, 0),
+        block_shape=(TILE_SIZE, D),
+        order=(1, 0),
+    )
+    src_index_2d = tl.make_block_ptr(
+        base=src_index,
+        shape=(TILE_SIZE, 1),
+        strides=(1, 1),
+        offsets=(0, 0),
+        block_shape=(TILE_SIZE, 1),
+        order=(1, 0),
+    )
+    tile_v = tl.full((TILE_SIZE, D), 0, DTYPE)
+    tile_v = tle.dsa.ascend.raw(
+        "gather_gm_to_ub",
+        src_2d,
+        src_index_2d,
+        TILE_SIZE,
+        D,
+        out=tile_v,
+    )
+
+    output_2d = tl.make_block_ptr(
+        base=output,
+        shape=(TILE_SIZE, D),
+        strides=(D, 1),
+        offsets=(0, 0),
+        block_shape=(TILE_SIZE, D),
+        order=(1, 0),
+    )
+    tl.store(output_2d, tile_v)
+
+
+@triton.jit
+def sort_pack_kernel(X, OutGM, N: tl.constexpr, K: tl.constexpr, INDEX_OFFSET: tl.constexpr, SORT_IMPL: tl.constexpr,
+                     TMP_SIZE: tl.constexpr):
+    """Single-segment sort_1d_pack: load N f32 values from GM into UB, sort,
+    then write the K proposals (2K f32) back to OutGM."""
+    NP2: tl.constexpr = triton.next_power_of_2(N)
+    KP2: tl.constexpr = triton.next_power_of_2(K * 2)
+    tmp = tl.zeros([TMP_SIZE], dtype=tl.float32)
+    src_ub = tle.dsa.alloc([N], dtype=tl.float32, mem_addr_space=tle.dsa.ascend.UB)
+    tle.dsa.copy(X + tl.arange(0, NP2), src_ub, [N])
+    props = tl.zeros([KP2], dtype=tl.float32)
+    props = tle.dsa.ascend.raw("sort_1d_pack", tle.dsa.to_tensor(src_ub), tmp, True, K, INDEX_OFFSET, SORT_IMPL,
+                               out=props)
+    tl.store(OutGM + tl.arange(0, KP2), props)
+
+
+@triton.jit
+def merge_exhaust_kernel(SrcGM, OutGM, ConsGM, WAY_CAP: tl.constexpr, WAYS: tl.constexpr, L0: tl.constexpr,
+                         L1: tl.constexpr, L2: tl.constexpr, L3: tl.constexpr, OUT_CAP: tl.constexpr):
+    """One merge_exhaust_sort4 call: the four proposal ways sit in a single
+    UB buffer at fixed offsets 0/1/2/3 * WAY_CAP; merge once, then write the
+    safe prefix and the per-way consumed counts back to GM."""
+    IN_LEN: tl.constexpr = 4 * WAY_CAP * 2
+    IN_P2: tl.constexpr = triton.next_power_of_2(IN_LEN)
+    OUT_P2: tl.constexpr = triton.next_power_of_2(OUT_CAP * 2)
+    in_ub = tle.dsa.alloc([IN_LEN], dtype=tl.float32, mem_addr_space=tle.dsa.ascend.UB)
+    out_t = tl.zeros([OUT_P2], dtype=tl.float32)
+    cons = tl.zeros([4], dtype=tl.int32)
+
+    tle.dsa.copy(SrcGM + tl.arange(0, IN_P2), in_ub, [IN_LEN])
+    out_t, cons = tle.dsa.ascend.raw("merge_exhaust_sort4", tle.dsa.to_tensor(in_ub), WAYS, 0 * WAY_CAP, 1 * WAY_CAP,
+                                     2 * WAY_CAP, 3 * WAY_CAP, L0, L1, L2, L3, out=[out_t, cons])
+
+    tl.store(OutGM + tl.arange(0, OUT_P2), out_t)
+    tl.store(ConsGM + tl.arange(0, 4), cons)
+
+
+@triton.jit
+def unpack_sort_kernel(SrcGM, Yv, Yi, K: tl.constexpr):
+    """unpack_sort: split K proposals into two GM outputs, value (f32) and
+    index (i32)."""
+    KP2: tl.constexpr = triton.next_power_of_2(K * 2)
+    s_ub = tle.dsa.alloc([K * 2], dtype=tl.float32, mem_addr_space=tle.dsa.ascend.UB)
+    dval = tl.zeros([K], dtype=tl.float32)
+    didx = tl.zeros([K], dtype=tl.int32)
+    offs = tl.arange(0, K)
+    tle.dsa.copy(SrcGM + tl.arange(0, KP2), s_ub, [K * 2])
+    dval, didx = tle.dsa.ascend.raw("unpack_sort", tle.dsa.to_tensor(s_ub), K, out=[dval, didx])
+    tl.store(Yv + offs, dval)
+    tl.store(Yi + offs, didx)
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# Host-side helpers
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def _encode_props(values, indices):
+    """(value f32, index i32) lists -> interleaved f32 numpy array
+    [v0, idx0_as_f32, v1, idx1_as_f32, ...]."""
+    raw = np.empty(2 * len(values), dtype=np.int32)
+    raw[0::2] = np.asarray(values, dtype=np.float32).view(np.int32)
+    raw[1::2] = np.asarray(indices, dtype=np.int32)
+    return raw.view(np.float32)
+
+
+def _decode_props(props):
+    """Interleaved proposal f32 array -> (value f32, index i32)."""
+    raw = np.ascontiguousarray(props, dtype=np.float32).view(np.int32)
+    return raw[0::2].view(np.float32), raw[1::2]
+
+
+def _sort_tmp_size(seg_len: int, sort_run_len: int, sort_impl: int) -> int:
+    if sort_impl == SORT_IMPL_BASE:
+        return seg_len * 4
+    if sort_impl == SORT_IMPL_S4096_K1_128_K2048:
+        props_ab = seg_len * 2
+        group_buf = 4 * 512 * 2
+        return 2 * props_ab + 2 * group_buf + (2 * group_buf + 8)
+    candidates = SMALLK_SORT_WAYS * sort_run_len * 2
+    chunk_tmp = SMALLK_SORT_CHUNK * 4
+    merge_out = SMALLK_SORT_WAYS * sort_run_len * 2
+    return candidates + chunk_tmp + merge_out
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# gather_gm_to_l1 / gather_gm_to_ub
+# ══════════════════════════════════════════════════════════════════════════
+
+NUM_ROWS = 32
+TILE_SIZE = 16
+D = 16
+L1_INDEX = [3, 4, 9, 10, 2, 7, 0, 1, 12, 13, 5, 8, 11, 6, 15, 14]
+UB_INDEX = [20, 21, 19, 30, 31, 25, 24, 18, 27, 28, 22, 29, 26, 23, 17, 16]
+
+_TL_DTYPE = {torch.float16: tl.float16, torch.bfloat16: tl.bfloat16}
+
+
+def test_gather_gm_to_l1(torch_dtype, tol):
+    torch.manual_seed(0)
+    src = torch.randn((NUM_ROWS, D), dtype=torch_dtype, device=DEVICE)
+    query = torch.randn((TILE_SIZE, D), dtype=torch_dtype, device=DEVICE)
+    output = torch.empty((TILE_SIZE, TILE_SIZE), dtype=torch.float32, device=DEVICE)
+    src_index = torch.tensor(L1_INDEX, dtype=torch.int32, device=DEVICE)
+
+    gather_gm_to_l1_dot_kernel[(1, )](
+        src,
+        src_index,
+        query,
+        output,
+        NUM_ROWS=NUM_ROWS,
+        TILE_SIZE=TILE_SIZE,
+        D=D,
+        DTYPE=_TL_DTYPE[torch_dtype],
+        disable_auto_cv_work_space_manage=True,
+    )
+    torch_npu.npu.synchronize()
+
+    gathered_src = src[src_index.long(), :]
+    expected = torch.matmul(query.float(), gathered_src.float().transpose(0, 1))
+    torch.testing.assert_close(output.cpu(), expected.cpu(), rtol=tol, atol=tol)
+    print(f"[PASS] gather_gm_to_l1 dot correctness ({torch_dtype})")
+
+
+def test_gather_gm_to_ub(torch_dtype):
+    torch.manual_seed(0)
+    src = torch.randn((NUM_ROWS, D), dtype=torch_dtype, device=DEVICE)
+    output = torch.empty((TILE_SIZE, D), dtype=torch_dtype, device=DEVICE)
+    src_index = torch.tensor(UB_INDEX, dtype=torch.int32, device=DEVICE)
+
+    gather_gm_to_ub_store_kernel[(1, )](
+        src,
+        src_index,
+        output,
+        NUM_ROWS=NUM_ROWS,
+        TILE_SIZE=TILE_SIZE,
+        D=D,
+        DTYPE=_TL_DTYPE[torch_dtype],
+        disable_auto_cv_work_space_manage=True,
+    )
+    torch_npu.npu.synchronize()
+
+    expected = src[src_index.long(), :]
+    torch.testing.assert_close(output.cpu(), expected.cpu(), rtol=0, atol=0)
+    print(f"[PASS] gather_gm_to_ub store correctness ({torch_dtype})")
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# sort_1d_pack
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def _run_sort_case(n, k, index_offset, sort_impl, label):
+    torch.manual_seed(0)
+    x = torch.rand((n, ), dtype=torch.float32, device=DEVICE)
+    out = torch.zeros((triton.next_power_of_2(k * 2), ), dtype=torch.float32, device=DEVICE)
+
+    sort_pack_kernel[(1, )](
+        x,
+        out,
+        N=n,
+        K=k,
+        INDEX_OFFSET=index_offset,
+        SORT_IMPL=sort_impl,
+        TMP_SIZE=_sort_tmp_size(n, k, sort_impl),
+    )
+    torch_npu.npu.synchronize()
+
+    values, indices = _decode_props(out.cpu().numpy()[:k * 2])
+    x_np = x.cpu().numpy()
+    ref = np.sort(x_np)[::-1][:k]
+
+    assert indices.min() >= index_offset and indices.max() < index_offset + n, (
+        f"{label}: index out of range [{indices.min()}, {indices.max()}]")
+    np.testing.assert_allclose(values, ref, rtol=1e-5, atol=1e-5,
+                               err_msg=f"{label}: values are not the descending top-{k}")
+    np.testing.assert_allclose(x_np[indices.astype(np.int64) - index_offset], values, rtol=1e-5, atol=1e-5,
+                               err_msg=f"{label}: index does not match value")
+    print(f"[PASS] sort_1d_pack {label} (N={n}, K={k}, offset={index_offset})")
+
+
+def test_sort_1d_pack():
+    # BASE generic path + a non-zero index_offset case
+    _run_sort_case(2048, 100, 0, SORT_IMPL_BASE, "BASE")
+    _run_sort_case(2048, 100, 500, SORT_IMPL_BASE, "BASE index_offset")
+    # 4x1024 small-K path: 4096 inputs, 128 < K <= 512
+    _run_sort_case(4096, 256, 0, SORT_IMPL_S4096_K129_512, "S4096_K129_512")
+    # Layered path: 4096 inputs; K <= 128 can early-stop, K == 2048 uses the
+    # fixed merge tree
+    _run_sort_case(4096, 64, 0, SORT_IMPL_S4096_K1_128_K2048, "S4096_K1_128_K2048 early-stop")
+    _run_sort_case(4096, 2048, 0, SORT_IMPL_S4096_K1_128_K2048, "S4096_K1_128_K2048 fixed-tree")
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# merge_exhaust_sort4
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def _make_way(rng, length, tag):
+    """Generate one descending proposal way: globally unique values with a
+    one-to-one value/index mapping."""
+    values = np.sort(rng.random(length))[::-1].astype(np.float32)
+    indices = np.arange(length, dtype=np.int32) + tag * 100000
+    return list(zip(values.tolist(), indices.astype(np.int64).tolist()))
+
+
+def _run_merge_case(lengths, label, seed=0):
+    rng = np.random.default_rng(seed)
+    way_cap = max(lengths)
+    src = np.zeros(4 * way_cap * 2, dtype=np.float32)
+    ways = []
+    for tag, ln in enumerate(lengths):
+        if ln > 0:
+            way = _make_way(rng, ln, tag)
+            ways.append((tag, way))
+            src[tag * way_cap * 2:tag * way_cap * 2 + ln * 2] = _encode_props(*zip(*way))
+
+    src_gm = torch.from_numpy(src).to(DEVICE)
+    out_gm = torch.zeros((4 * way_cap * 2, ), dtype=torch.float32, device=DEVICE)
+    cons_gm = torch.zeros((4, ), dtype=torch.int32, device=DEVICE)
+
+    merge_exhaust_kernel[(1, )](
+        src_gm,
+        out_gm,
+        cons_gm,
+        WAY_CAP=way_cap,
+        WAYS=sum(1 for ln in lengths if ln > 0),
+        L0=lengths[0],
+        L1=lengths[1],
+        L2=lengths[2],
+        L3=lengths[3],
+        OUT_CAP=4 * way_cap,
+    )
+    torch_npu.npu.synchronize()
+
+    cons = cons_gm.cpu().numpy()
+    total = int(cons[:len(lengths)].sum())
+    assert total > 0, f"{label}: merge produced no output"
+    for tag, ln in enumerate(lengths):
+        assert 0 <= cons[tag] <= ln, (f"{label}: way{tag} consumed count {cons[tag]} exceeds length {ln}")
+
+    out_v, out_i = _decode_props(out_gm.cpu().numpy()[:total * 2])
+    assert np.all(out_v[:-1] >= out_v[1:]), f"{label}: output prefix is not descending"
+
+    out_pairs = list(zip(out_v.tolist(), out_i.tolist()))
+    full_merge = sorted((p for _, way in ways for p in way), key=lambda p: -p[0])
+    assert out_pairs == full_merge[:total], (f"{label}: output is not a safe prefix of the full merge")
+
+    value_to_way = {p[0]: tag for tag, way in ways for p in way}
+    for tag, way in ways:
+        used = [p for p in out_pairs if value_to_way[p[0]] == tag]
+        assert used == way[:cons[tag]], (
+            f"{label}: way{tag} proposals actually consumed do not match the reported consumed count")
+    print(f"[PASS] merge_exhaust_sort4 {label} "
+          f"(lens={lengths}, consumed={cons[:len(lengths)].tolist()}, total={total})")
+
+
+def test_merge_exhaust_sort4():
+    _run_merge_case((64, 64, 64, 64), "4-way")
+    _run_merge_case((64, 64, 0, 0), "2-way")
+    _run_merge_case((64, 0, 64, 32), "3-way with hole")
+
+
+# ══════════════════════════════════════════════════════════════════════════
+# unpack_sort
+# ══════════════════════════════════════════════════════════════════════════
+
+
+def test_unpack_sort():
+    rng = np.random.default_rng(0)
+    k = 128
+    values = np.sort(rng.random(k))[::-1].astype(np.float32)
+    indices = rng.integers(0, 10000, size=k).astype(np.int32)
+    src = torch.from_numpy(_encode_props(values, indices)).to(DEVICE)
+    yv = torch.zeros((k, ), dtype=torch.float32, device=DEVICE)
+    yi = torch.zeros((k, ), dtype=torch.int32, device=DEVICE)
+
+    unpack_sort_kernel[(1, )](src, yv, yi, K=k)
+    torch_npu.npu.synchronize()
+
+    np.testing.assert_array_equal(yv.cpu().numpy(), values, err_msg="unpack_sort values mismatch")
+    np.testing.assert_array_equal(yi.cpu().numpy(), indices, err_msg="unpack_sort indices mismatch")
+    print("[PASS] unpack_sort correctness")
+
+
+def main():
+    for torch_dtype, tol in ((torch.float16, 1e-3), (torch.bfloat16, 1e-2)):
+        test_gather_gm_to_l1(torch_dtype, tol)
+        test_gather_gm_to_ub(torch_dtype)
+    test_sort_1d_pack()
+    test_merge_exhaust_sort4()
+    test_unpack_sort()
+    print("\nAll custom op correctness tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -900,6 +900,12 @@ setup(
     ],
     packages=list(get_packages()),
     package_dir=dict(get_package_dirs()),
+    package_data={
+        # Pre-built custom-op bitcode, required at runtime by
+        # triton/experimental/tle/language/dsa/ascend/custom_ops/registry.py.
+        # Same convention as triton/backends/*/lib/libdevice.10.bc.
+        "triton.experimental.tle.language.dsa.ascend.custom_ops": ["custom_ops.bc"],
+    },
     entry_points=get_entry_points(),
     include_package_data=True,
     ext_modules=[CMakeExtension("triton", "triton/_C/")],

--- a/third_party/ascend/CMakeLists.txt
+++ b/third_party/ascend/CMakeLists.txt
@@ -54,6 +54,7 @@ add_triton_plugin(TritonAscend
   BiShengIRHIVMDialect
   ${_MLIRMeshDialect_LIB}
 )
+add_dependencies(TritonAscend AscendCustomOpsBitcode)
 
 target_include_directories(TritonAscend BEFORE PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/python/src)

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -909,6 +909,7 @@ class NPUOptions:
     enable_preload: bool = None
     enable_auto_bind_sub_block: bool = None
     disable_tightly_coupled_buffer_reuse: bool = False
+    disable_auto_cv_work_space_manage: bool = None
     enable_select_analysis: bool = True
     enable_hivm_auto_cv_balance: bool = None
     sync_solver: bool = None

--- a/third_party/tle/dsa/dialect/lib/CMakeLists.txt
+++ b/third_party/tle/dsa/dialect/lib/CMakeLists.txt
@@ -1,5 +1,139 @@
 # Copyright 2026- Xcoresigma Technology Co., Ltd
 
+set(ASCEND_CUSTOM_OPS_DIR "${PROJECT_SOURCE_DIR}/python/triton/experimental/tle/language/dsa/ascend/custom_ops")
+set(ASCEND_CUSTOM_OPS_BITCODE "${ASCEND_CUSTOM_OPS_DIR}/custom_ops.bc")
+
+# ccec / llvm-link come from the CANN environment. If they are not on PATH at
+# configure time, fall back to bare names resolved from PATH at build time
+# (same behaviour as build_custom_ops.sh, kept for manual rebuilds).
+find_program(CCEC_EXECUTABLE ccec)
+if(NOT CCEC_EXECUTABLE)
+  message(STATUS "ccec not found at configure time, deferring lookup to build time")
+  set(CCEC_EXECUTABLE ccec)
+endif()
+get_filename_component(CCEC_BIN_DIR "${CCEC_EXECUTABLE}" DIRECTORY)
+find_program(LLVM_LINK_EXECUTABLE llvm-link HINTS "${CCEC_BIN_DIR}")
+if(NOT LLVM_LINK_EXECUTABLE)
+  set(LLVM_LINK_EXECUTABLE llvm-link)
+endif()
+
+set(TEMPLATE_ROOT "${PROJECT_SOURCE_DIR}/third_party/ascend/AscendNPU-IR/bishengir/lib/Template")
+set(TEMPLATE_INCLUDE "${TEMPLATE_ROOT}/include")
+
+set(CCEC_COMMON_FLAGS
+  -O2 -x cce --cce-auto-sync=off --cce-aicore-only
+  --cce-generic-addrspace=off -mllvm -disable-llvm-optzns
+  --cce-enable-print --cce-enable-sanitizer -std=c++17)
+
+set(ASCEND_CUSTOM_OPS_BC_DIR "${CMAKE_CURRENT_BINARY_DIR}/ascend_custom_ops")
+
+# Each custom op is implemented in its own .cpp and compiled into its own
+# bitcode: "<src>::<arch>" — arch is the ccec aicore target for that op.
+set(ASCEND_CUSTOM_OPS
+  "mem_ops/gather_gm_to_l1.cpp::dav-c220-cube"
+  "mem_ops/gather_gm_to_ub.cpp::dav-c220-vec"
+  "sort_ops/sort_1d_pack.cpp::dav-c220-vec"
+  "sort_ops/merge_pack_sort.cpp::dav-c220-vec"
+  "sort_ops/unpack_sort.cpp::dav-c220-vec"
+)
+
+set(SORT_OPS_DIR "${ASCEND_CUSTOM_OPS_DIR}/sort_ops")
+set(OP_BITCODES "")
+foreach(entry IN LISTS ASCEND_CUSTOM_OPS)
+  string(REPLACE "::" ";" entry_parts "${entry}")
+  list(GET entry_parts 0 src)
+  list(GET entry_parts 1 arch)
+
+  set(op_deps "")
+  if(src MATCHES "^sort_ops/")
+    list(APPEND op_deps "${SORT_OPS_DIR}/sort_common.h")
+  endif()
+  if(src STREQUAL "sort_ops/sort_1d_pack.cpp")
+    list(APPEND op_deps
+      "${SORT_OPS_DIR}/sort_base.h"
+      "${SORT_OPS_DIR}/sort_s4096_k129_512.h"
+      "${SORT_OPS_DIR}/sort_s4096_k1_128_k2048.h")
+  endif()
+
+  set(bc "${ASCEND_CUSTOM_OPS_BC_DIR}/${src}.bc")
+  set(mix_bc "${ASCEND_CUSTOM_OPS_BC_DIR}/${src}.mix.bc")
+  list(APPEND OP_BITCODES "${bc}" "${mix_bc}")
+  add_custom_command(
+    OUTPUT "${bc}"
+    COMMAND "${CCEC_EXECUTABLE}" ${CCEC_COMMON_FLAGS}
+      --cce-aicore-arch=${arch}
+      -I "${TEMPLATE_INCLUDE}"
+      "${ASCEND_CUSTOM_OPS_DIR}/${src}"
+      -emit-llvm -c -o "${bc}"
+    DEPENDS "${ASCEND_CUSTOM_OPS_DIR}/${src}" ${op_deps}
+    COMMENT "ccec ${src} (${arch})"
+    VERBATIM
+  )
+  add_custom_command(
+    OUTPUT "${mix_bc}"
+    COMMAND "${CCEC_EXECUTABLE}" ${CCEC_COMMON_FLAGS}
+      --cce-aicore-arch=${arch}
+      -cce-enable-mix -mllvm -enable-mix=true
+      -I "${TEMPLATE_INCLUDE}"
+      "${ASCEND_CUSTOM_OPS_DIR}/${src}"
+      -emit-llvm -c -o "${mix_bc}"
+    DEPENDS "${ASCEND_CUSTOM_OPS_DIR}/${src}" ${op_deps}
+    COMMENT "ccec ${src} (${arch}, mix)"
+    VERBATIM
+  )
+endforeach()
+
+set(TEMPLATE_OPS
+  "lib/Vector/Arange/Arange1D.cpp"
+  "lib/Vector/Elementwise/EltWise1D.cpp"
+  "lib/Vector/Sort/Sort1D.cpp"
+  "lib/DMA/Ubuf/Copy1D.cpp"
+)
+
+set(TEMPLATE_BITCODES "")
+foreach(src IN LISTS TEMPLATE_OPS)
+  get_filename_component(name_we "${src}" NAME_WE)
+  set(bc "${ASCEND_CUSTOM_OPS_BC_DIR}/template_${name_we}.bc")
+  set(mix_bc "${ASCEND_CUSTOM_OPS_BC_DIR}/template_${name_we}.mix.bc")
+  list(APPEND TEMPLATE_BITCODES "${bc}" "${mix_bc}")
+  add_custom_command(
+    OUTPUT "${bc}"
+    COMMAND "${CCEC_EXECUTABLE}" ${CCEC_COMMON_FLAGS}
+      --cce-aicore-arch=dav-c220-vec
+      -I "${TEMPLATE_INCLUDE}"
+      "${TEMPLATE_ROOT}/${src}"
+      -emit-llvm -c -o "${bc}"
+    DEPENDS "${TEMPLATE_ROOT}/${src}"
+    COMMENT "ccec Template ${src}"
+    VERBATIM
+  )
+  add_custom_command(
+    OUTPUT "${mix_bc}"
+    COMMAND "${CCEC_EXECUTABLE}" ${CCEC_COMMON_FLAGS}
+      --cce-aicore-arch=dav-c220-vec
+      -cce-enable-mix -mllvm -enable-mix=true
+      -I "${TEMPLATE_INCLUDE}"
+      "${TEMPLATE_ROOT}/${src}"
+      -emit-llvm -c -o "${mix_bc}"
+    DEPENDS "${TEMPLATE_ROOT}/${src}"
+    COMMENT "ccec Template ${src} (mix)"
+    VERBATIM
+  )
+endforeach()
+
+add_custom_command(
+  OUTPUT "${ASCEND_CUSTOM_OPS_BITCODE}"
+  COMMAND "${LLVM_LINK_EXECUTABLE}" ${OP_BITCODES} ${TEMPLATE_BITCODES}
+    -o "${ASCEND_CUSTOM_OPS_BITCODE}"
+  DEPENDS ${OP_BITCODES} ${TEMPLATE_BITCODES}
+  COMMENT "llvm-link -> ${ASCEND_CUSTOM_OPS_BITCODE}"
+  VERBATIM
+)
+
+add_custom_target(AscendCustomOpsBitcode
+  DEPENDS "${ASCEND_CUSTOM_OPS_BITCODE}"
+)
+
 add_subdirectory(Analysis)
 add_subdirectory(IR)
 # Conversion depends on the main TleIR target, so it is added by


### PR DESCRIPTION
<!-- PR Title Format:
[TLE][BUILD][TEST][CI/CD][DOC][PROTON][BACKEND][FLIR] Brief description
[LANGUAGE][AUTOTUNER][LAYOUT][PIPELINE][WarpSpecialization] Brief description
Do not set the following title tags: [FEATURE][BUG][FixBug][Refine] ...
-->
Add custom op on Ascend:
1. gather_gm_to_l1; 2. gather_gm_to_ub: 
The above 2 ops are for the indirect addressing from GM to UB or L1.
4. sort_1d_pack; 4. merge_exhaust_sort4; 5. unpack_sort;
These 3 new ops are for sorting, we design these ops according to AscendC related OP implementation.