### PR TITLE
[BUILD] Add an ubuntu22.04/python3.12 DEB matrix row (FlagOS DEB ABI matrix)

### DIFF
--- a/.github/workflows/build-deb.yml
+++ b/.github/workflows/build-deb.yml
@@ -50,6 +50,26 @@ jobs:
     # `runs-on: h20`) once one is wired up.
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Original row; artifact name unchanged so downstream collectors
+          # (upload-nexus) keep working.
+          - target: ubuntu2404
+            base_image: ubuntu:24.04
+            python_version: ""
+            artifact: flagtree-nvidia-packages
+          # FlagOS DEB ABI-matrix row (FEP-0019): ubuntu22.04 + python3.12.
+          # A 22.04 build also installs on 24.04; the reverse does not hold
+          # (GLIBC_2.38 / GLIBCXX_3.4.32), see #798.
+          - target: ubuntu2204
+            base_image: ubuntu:22.04
+            python_version: "3.12"
+            artifact: flagtree-nvidia-ubuntu2204-packages
+    env:
+      DEB_BASE_IMAGE: ${{ matrix.base_image }}
+      PYTHON_VERSION: ${{ matrix.python_version }}
     steps:
       # The wheel build peaks near the runner's free-disk limit.
       # Ephemeral GitHub-hosted VMs only — never a self-hosted machine.
@@ -71,12 +91,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Build .deb
+      - name: Build .deb (${{ matrix.target }})
         run: bash packaging/debian/build-helpers/build-flagtree.sh
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7
         with:
-          name: flagtree-nvidia-packages
+          name: ${{ matrix.artifact }}
           path: dist/output/*.deb
           retention-days: 7

--- a/packaging/debian/build-helpers/Dockerfile.deb
+++ b/packaging/debian/build-helpers/Dockerfile.deb
@@ -139,18 +139,24 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         debhelper dh-python python3-all python3-pip python3-setuptools \
         python3-wheel devscripts fakeroot lintian software-properties-common gnupg \
+        curl ca-certificates \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Same interpreter as the wheel-builder stage, so the .deb is assembled,
 # installed and smoke-tested with the CPython the wheel was built for.
+# The distro's python3-pip / dh-python are written for the distro python; on
+# a newer interpreter they need a pip that lives in /usr/local (ahead of
+# /usr/lib/python3/dist-packages on sys.path) plus setuptools, whose
+# _distutils_hack keeps `import distutils` working on Python >= 3.12.
 RUN if [ -n "${PYTHON_VERSION}" ] && ! python3 --version 2>&1 | grep -q " ${PYTHON_VERSION}\."; then \
         add-apt-repository -y ppa:deadsnakes/ppa && apt-get update && \
         apt-get install -y --no-install-recommends \
             python${PYTHON_VERSION} python${PYTHON_VERSION}-venv && \
         update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 && \
-        python3 -m ensurepip && \
+        curl -sS https://bootstrap.pypa.io/get-pip.py | python3 && \
+        python3 -m pip install --no-cache-dir setuptools wheel && \
         apt-get clean && rm -rf /var/lib/apt/lists/*; \
-    fi && python3 --version
+    fi && python3 --version && python3 -m pip --version
 
 WORKDIR /build
 COPY packaging/debian /build/debian

--- a/packaging/debian/build-helpers/Dockerfile.deb
+++ b/packaging/debian/build-helpers/Dockerfile.deb
@@ -52,9 +52,11 @@ ARG DEB_BASE_IMAGE=ubuntu:24.04
 # then use that interpreter, so the wheel, the .deb and the smoke test agree.
 ARG PYTHON_VERSION=
 ARG MAX_JOBS=4
-# DEB_VERSION_SUFFIX: "auto" appends ~<id><version> (e.g. ~ubuntu22.04) to the
+# DEB_VERSION_SUFFIX: "auto" appends +<id><version> (e.g. +ubuntu22.04) to the
 # package version so rows built for different releases can coexist in one apt
-# suite (same convention as Docker CE). Empty keeps the changelog version.
+# suite (Docker CE does the same with ~ubuntu.22.04~jammy). "+" sorts above the
+# plain changelog version, so an unsuffixed package already installed from an
+# earlier build upgrades cleanly. Empty keeps the changelog version.
 ARG DEB_VERSION_SUFFIX=auto
 
 # ---------- Stage 1: build the wheel ----------
@@ -159,12 +161,12 @@ ENV WHEEL_DIR=/build/dist
 
 # Per-release version suffix (see DEB_VERSION_SUFFIX above).
 RUN if [ "${DEB_VERSION_SUFFIX}" = "auto" ]; then \
-        . /etc/os-release && suffix="~${ID}${VERSION_ID}"; \
+        . /etc/os-release && suffix="+${ID}${VERSION_ID}"; \
     else suffix="${DEB_VERSION_SUFFIX}"; fi && \
     if [ -n "${suffix}" ]; then \
         base="$(dpkg-parsechangelog -l debian/changelog -SVersion)" && \
         DEBFULLNAME="FlagOS Contributors" DEBEMAIL="contact@flagos.io" \
-        dch -v "${base}${suffix}" -D unstable --force-distribution \
+        dch -b -v "${base}${suffix}" -D unstable --force-distribution \
             "Rebuild for $(. /etc/os-release && echo "${PRETTY_NAME}")." && \
         echo "Package version: $(dpkg-parsechangelog -l debian/changelog -SVersion)"; \
     fi

--- a/packaging/debian/build-helpers/Dockerfile.deb
+++ b/packaging/debian/build-helpers/Dockerfile.deb
@@ -46,10 +46,22 @@
 # var explicitly in the wheel-build RUN.
 
 ARG DEB_BASE_IMAGE=ubuntu:24.04
+# PYTHON_VERSION: empty = the base image's default python3 (24.04: 3.12).
+# Set e.g. 3.12 on ubuntu:22.04 to build the FlagOS DEB ABI-matrix row
+# (ubuntu22.04 + python3.12, FEP-0019) from the deadsnakes PPA; both stages
+# then use that interpreter, so the wheel, the .deb and the smoke test agree.
+ARG PYTHON_VERSION=
+ARG MAX_JOBS=4
+# DEB_VERSION_SUFFIX: "auto" appends ~<id><version> (e.g. ~ubuntu22.04) to the
+# package version so rows built for different releases can coexist in one apt
+# suite (same convention as Docker CE). Empty keeps the changelog version.
+ARG DEB_VERSION_SUFFIX=auto
 
 # ---------- Stage 1: build the wheel ----------
 FROM ${DEB_BASE_IMAGE} AS wheel-builder
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG PYTHON_VERSION
+ARG MAX_JOBS
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV VIRTUAL_ENV=/opt/flagtree-build-venv
@@ -60,8 +72,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 python3-pip python3-dev python3-venv \
         build-essential cmake ninja-build git \
         zlib1g zlib1g-dev libxml2 libxml2-dev nlohmann-json3-dev \
-        wget curl ca-certificates \
+        wget curl ca-certificates software-properties-common gnupg \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Optional non-default interpreter (deadsnakes PPA), made the default python3.
+RUN if [ -n "${PYTHON_VERSION}" ] && ! python3 --version 2>&1 | grep -q " ${PYTHON_VERSION}\."; then \
+        add-apt-repository -y ppa:deadsnakes/ppa && apt-get update && \
+        apt-get install -y --no-install-recommends \
+            python${PYTHON_VERSION} python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv && \
+        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 && \
+        apt-get clean && rm -rf /var/lib/apt/lists/*; \
+    fi && python3 --version
 
 # Ubuntu 24.04 marks /usr Python as externally managed (PEP 668). Keep all
 # wheel-builder pip installs inside a venv instead of mutating system Python.
@@ -98,7 +119,7 @@ COPY CMakeLists.txt pyproject.toml setup.py MANIFEST.in LICENSE README.md /src/
 RUN unset FLAGTREE_BACKEND && \
     JSON_SYSPATH=/usr \
     FLAGTREE_DEFAULT_BACKENDS=nvidia,amd \
-    MAX_JOBS=4 python -m pip wheel . --no-build-isolation --no-deps -w /wheels -v && \
+    MAX_JOBS=${MAX_JOBS} python -m pip wheel . --no-build-isolation --no-deps -w /wheels -v && \
     ls -lh /wheels/ && \
     test -n "$(ls /wheels/flagtree-*.whl 2>/dev/null)" && \
     rm -rf /src/build /root/.triton
@@ -106,6 +127,8 @@ RUN unset FLAGTREE_BACKEND && \
 # ---------- Stage 2: assemble the .deb ----------
 FROM ${DEB_BASE_IMAGE} AS deb-assembler
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG PYTHON_VERSION
+ARG DEB_VERSION_SUFFIX
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PIP_ROOT_USER_ACTION=ignore
@@ -113,8 +136,19 @@ ENV PIP_ROOT_USER_ACTION=ignore
 RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         debhelper dh-python python3-all python3-pip python3-setuptools \
-        python3-wheel devscripts fakeroot lintian \
+        python3-wheel devscripts fakeroot lintian software-properties-common gnupg \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Same interpreter as the wheel-builder stage, so the .deb is assembled,
+# installed and smoke-tested with the CPython the wheel was built for.
+RUN if [ -n "${PYTHON_VERSION}" ] && ! python3 --version 2>&1 | grep -q " ${PYTHON_VERSION}\."; then \
+        add-apt-repository -y ppa:deadsnakes/ppa && apt-get update && \
+        apt-get install -y --no-install-recommends \
+            python${PYTHON_VERSION} python${PYTHON_VERSION}-venv && \
+        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1 && \
+        python3 -m ensurepip && \
+        apt-get clean && rm -rf /var/lib/apt/lists/*; \
+    fi && python3 --version
 
 WORKDIR /build
 COPY packaging/debian /build/debian
@@ -122,6 +156,18 @@ COPY --from=wheel-builder /wheels /build/dist
 
 # debian/source/format = "3.0 (native)" -> no orig.tar.gz needed.
 ENV WHEEL_DIR=/build/dist
+
+# Per-release version suffix (see DEB_VERSION_SUFFIX above).
+RUN if [ "${DEB_VERSION_SUFFIX}" = "auto" ]; then \
+        . /etc/os-release && suffix="~${ID}${VERSION_ID}"; \
+    else suffix="${DEB_VERSION_SUFFIX}"; fi && \
+    if [ -n "${suffix}" ]; then \
+        base="$(dpkg-parsechangelog -l debian/changelog -SVersion)" && \
+        DEBFULLNAME="FlagOS Contributors" DEBEMAIL="contact@flagos.io" \
+        dch -v "${base}${suffix}" -D unstable --force-distribution \
+            "Rebuild for $(. /etc/os-release && echo "${PRETTY_NAME}")." && \
+        echo "Package version: $(dpkg-parsechangelog -l debian/changelog -SVersion)"; \
+    fi
 
 RUN dpkg-buildpackage -us -uc -b && \
     ls -lh /python3-flagtree-*.deb

--- a/packaging/debian/build-helpers/build-flagtree.sh
+++ b/packaging/debian/build-helpers/build-flagtree.sh
@@ -31,9 +31,23 @@ cd "$REPO_ROOT"
 
 mkdir -p dist
 
-echo ">>> Building wheel + .deb for backend=${BACKEND}"
+# Build-environment knobs (see Dockerfile.deb):
+#   DEB_BASE_IMAGE     ubuntu:24.04 (default) | ubuntu:22.04
+#   PYTHON_VERSION     empty = base image default | e.g. 3.12 (deadsnakes on 22.04)
+#   MAX_JOBS           parallel compile jobs for the wheel (default 4; the MLIR
+#                      build needs roughly 2-3 GB RAM per job)
+#   DEB_VERSION_SUFFIX auto (~ubuntu<ver>) | "" | explicit suffix
+DEB_BASE_IMAGE="${DEB_BASE_IMAGE:-ubuntu:24.04}"
+PYTHON_VERSION="${PYTHON_VERSION:-}"
+MAX_JOBS="${MAX_JOBS:-4}"
+DEB_VERSION_SUFFIX="${DEB_VERSION_SUFFIX:-auto}"
+echo ">>> Building wheel + .deb for backend=${BACKEND} on ${DEB_BASE_IMAGE} (python ${PYTHON_VERSION:-default}, MAX_JOBS=${MAX_JOBS})"
 docker build \
     --network=host \
+    --build-arg DEB_BASE_IMAGE="${DEB_BASE_IMAGE}" \
+    --build-arg PYTHON_VERSION="${PYTHON_VERSION}" \
+    --build-arg MAX_JOBS="${MAX_JOBS}" \
+    --build-arg DEB_VERSION_SUFFIX="${DEB_VERSION_SUFFIX}" \
     -f packaging/debian/build-helpers/Dockerfile.deb \
     --target deb-output \
     --output "type=local,dest=${REPO_ROOT}/dist" \

--- a/packaging/debian/build-helpers/build-flagtree.sh
+++ b/packaging/debian/build-helpers/build-flagtree.sh
@@ -36,7 +36,7 @@ mkdir -p dist
 #   PYTHON_VERSION     empty = base image default | e.g. 3.12 (deadsnakes on 22.04)
 #   MAX_JOBS           parallel compile jobs for the wheel (default 4; the MLIR
 #                      build needs roughly 2-3 GB RAM per job)
-#   DEB_VERSION_SUFFIX auto (~ubuntu<ver>) | "" | explicit suffix
+#   DEB_VERSION_SUFFIX auto (+ubuntu<ver>) | "" | explicit suffix
 DEB_BASE_IMAGE="${DEB_BASE_IMAGE:-ubuntu:24.04}"
 PYTHON_VERSION="${PYTHON_VERSION:-}"
 MAX_JOBS="${MAX_JOBS:-4}"

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -21,7 +21,7 @@ X-Build-Environment: This package wraps a pre-built FlagTree wheel into a .deb.
 
 Package: python3-flagtree-nvidia
 Architecture: amd64
-Depends: python3:any,
+Depends: ${python:Depends},
          ${shlibs:Depends},
          ${misc:Depends},
          python3-filelock,

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -41,6 +41,18 @@ override_dh_auto_install:
 	# otherwise dh_python3 warns. Easiest: drop RECORD; pip doesn't need it.
 	rm -f $(PYDIR)/flagtree-*.dist-info/RECORD
 
+# The wheel is CPython-minor specific (cpXY tag); depend on exactly that
+# interpreter package (python3.12 exists on 22.04 via deadsnakes and on 24.04
+# natively) instead of the unversioned python3:any.
+override_dh_gencontrol:
+	@wheel="$$(ls -1 $(WHEEL_DIR)/flagtree-*.whl | head -1)"; \
+	tag="$$(basename "$$wheel" | sed -E 's/.*-(cp3[0-9]+)-cp3[0-9]+.*/\1/')"; \
+	case "$$tag" in cp3[0-9]*) ;; *) echo "ERROR: cannot read CPython tag from $$wheel"; exit 1;; esac; \
+	pyver="3.$${tag#cp3}"; \
+	echo "python:Depends=python$$pyver" >> debian/$(PKG).substvars; \
+	echo "Wheel targets CPython $$pyver -> Depends: python$$pyver"
+	dh_gencontrol
+
 override_dh_shlibdeps:
 	# triton/_C/*.so link against libcuda.so etc. Those libs are not present
 	# at packaging time and cannot be expressed via shlibs anyway, so skip


### PR DESCRIPTION
## Why

`build-deb.yml` only builds on `ubuntu:24.04`; the resulting `libtriton.so` requires `GLIBC_2.38` / `GLIBCXX_3.4.32`, so the package declares `libc6 (>= 2.38)` and cannot be installed on Ubuntu 22.04 at all (#798, item 1). The FlagOS DEB ABI matrix (FEP-0019, flagos-ai/community#59) is **ubuntu22.04 + python3.12**, which is also what libtriton_jit#61 and FlagFFT#12 build on — a 22.04 build installs on both 22.04 and 24.04, the reverse does not hold.

## What

- **New matrix row** `ubuntu2204` (`ubuntu:22.04`, python 3.12 from the deadsnakes PPA), artifact `flagtree-nvidia-ubuntu2204-packages`. The original `ubuntu2404` row and its artifact name are unchanged, so upload-nexus (#1063) keeps working.
- **`Dockerfile.deb`** gains `PYTHON_VERSION` / `MAX_JOBS` / `DEB_VERSION_SUFFIX` build args. The interpreter is installed in *both* stages, so the wheel, the .deb and the existing `import triton` smoke test agree on the CPython the package is for.
- **Version suffix**: with `DEB_VERSION_SUFFIX=auto` (default) the package version becomes `0.6.0-1+ubuntu22.04` / `+ubuntu24.04` (Docker CE does the same with `~ubuntu.22.04~jammy`; `+` is used here so the suffixed package sorts above and upgrades an unsuffixed one), so rows built for different releases can coexist in one apt suite instead of colliding on the same filename (flagos-ai/build-infra#600). Set it to "" to keep the plain changelog version.
- **`Depends: python3.X`** derived from the wheel's `cpXY` tag in `debian/rules` instead of the unversioned `python3:any` — the extension is CPython-minor specific, and `python3.12` exists on 22.04 (deadsnakes) and 24.04 natively.
- `build-flagtree.sh` passes the knobs through as env vars (`DEB_BASE_IMAGE`, `PYTHON_VERSION`, `MAX_JOBS`, `DEB_VERSION_SUFFIX`).

## Notes

- The 22.04 row builds the full MLIR wheel like the 24.04 one (~36 min / >4 GB on a 4-core runner); the job-level warning about `ubuntu-latest` headroom applies to both rows. `fail-fast: false` so one row cannot cancel the other.
- The other #798 items (rpath re-check on 0.6.x, backend-branch packaging, vendor runtime deps) are not touched here.

Refs #798.
