### PR TITLE
[Tsingmicro] Add TLE DSA elementwise/randgen/bitcast ops and tx81 launch fast path

### DIFF
--- a/third_party/tle/include/tle-dsa/Dialect/IR/DsaOps.td
+++ b/third_party/tle/include/tle-dsa/Dialect/IR/DsaOps.td
@@ -40,6 +40,41 @@ def Dsa_CopyOp : Dsa_Op<"copy",
   }];
 }
 
+//===----------------------------------------------------------------------===//
+// dsa.add / dsa.sub / dsa.mul / dsa.maximum / dsa.minimum / dsa.div
+// Elementwise binary arithmetic on local memrefs (three-operand: out = lhs OP rhs).
+//===----------------------------------------------------------------------===//
+
+class Dsa_BinaryOp<string mnemonic> : Dsa_Op<mnemonic,
+    [MemoryEffects<[MemRead, MemWrite]>]> {
+  let arguments = (ins AnyRankedOrUnrankedMemRef:$lhs,
+                       AnyRankedOrUnrankedMemRef:$rhs,
+                       AnyRankedOrUnrankedMemRef:$out);
+  let results = (outs);
+  let assemblyFormat = [{
+    $lhs `,` $rhs `,` $out attr-dict `:` type($lhs) `,` type($rhs) `,` type($out)
+  }];
+}
+
+def Dsa_AddOp : Dsa_BinaryOp<"add"> {
+  let summary = "elementwise add on local memrefs (out = lhs + rhs)";
+}
+def Dsa_SubOp : Dsa_BinaryOp<"sub"> {
+  let summary = "elementwise subtract on local memrefs (out = lhs - rhs)";
+}
+def Dsa_MulOp : Dsa_BinaryOp<"mul"> {
+  let summary = "elementwise multiply on local memrefs (out = lhs * rhs)";
+}
+def Dsa_MaximumOp : Dsa_BinaryOp<"maximum"> {
+  let summary = "elementwise maximum on local memrefs (out = max(lhs, rhs))";
+}
+def Dsa_MinimumOp : Dsa_BinaryOp<"minimum"> {
+  let summary = "elementwise minimum on local memrefs (out = min(lhs, rhs))";
+}
+def Dsa_DivOp : Dsa_BinaryOp<"div"> {
+  let summary = "elementwise divide on local memrefs (out = lhs / rhs)";
+}
+
 def DsaLocalPointerResultType : AnyTypeOf<[TT_Tensor, TT_Ptr]>;
 def DsaLocalPointerIndexType : AnyTypeOf<[TT_Tensor, TT_Int]>;
 def DsaRemotePointerType : AnyTypeOf<[TT_Tensor, TT_Ptr]>;
@@ -77,6 +112,34 @@ def Dsa_RemotePointersOp : Dsa_Op<"remote_pointers", [Pure]> {
   let results = (outs DsaRemotePointerType:$result);
 }
 
+//===----------------------------------------------------------------------===//
+// dsa.to_tensor / dsa.to_buffer
+//
+// Explicit buffer <-> tensor bridging:
+//   - dsa.to_tensor: SPM buffer (memref) -> tl.tensor zero-copy view.
+//     Lowered by TLEToMK to bufferization.to_tensor(memref, restrict, writable).
+//   - dsa.to_buffer: tl.tensor -> copy into an existing SPM buffer (memref).
+//     Lowered by TLEToMK to bufferization.to_memref + memref.copy.
+//===----------------------------------------------------------------------===//
+
+def Dsa_ToTensorOp : Dsa_Op<"to_tensor", [Pure]> {
+  let summary = "Convert a DSA local buffer (memref) to a tl.tensor view";
+  let arguments = (ins AnyRankedOrUnrankedMemRef:$src, BoolAttr:$writable);
+  let results = (outs TT_Tensor:$result);
+  let assemblyFormat = [{
+    $src attr-dict `:` type($src) `->` type($result)
+  }];
+}
+
+def Dsa_ToBufferOp : Dsa_Op<"to_buffer", [MemoryEffects<[MemRead, MemWrite]>]> {
+  let summary = "Copy a tl.tensor value into an existing DSA local buffer (memref)";
+  let arguments = (ins TT_Tensor:$src, AnyRankedOrUnrankedMemRef:$dst);
+  let results = (outs);
+  let assemblyFormat = [{
+    $src `,` $dst attr-dict `:` type($src) `,` type($dst)
+  }];
+}
+
 def DsaCumsumInputType : RankedTensorOf<[TT_Float, TT_Int]>;
 def DsaCumsumTotalResultType : AnyTypeOf<[DsaCumsumInputType, TT_Float, TT_Int]>;
 
@@ -97,6 +160,91 @@ def Dsa_CumsumOp : Dsa_Op<"cumsum", [Pure]> {
     DsaCumsumInputType:$exclusive,
     DsaCumsumTotalResultType:$total
   );
+}
+
+//===----------------------------------------------------------------------===//
+// dsa.randgen for tsingmicro tx81
+//===----------------------------------------------------------------------===//
+
+def DsaRandGenSeedType : RankedTensorOf<[I64]>;
+def DsaRandGenOutType : RankedTensorOf<[I64]>;
+
+def Dsa_RandGenOp : Dsa_Op<"randgen",
+    [MemoryEffects<[MemRead, MemWrite]>]> {
+  let summary = "randgen for tsingmicro tx81";
+  let description = [{
+    Emits a single TX81 peri RandGen call. `seed0`/`seed1` are length-16 i64
+    seed vectors; `byte_count` is the random output size in bytes and must be
+    a multiple of 128. Results are `(out, seed0_out, seed1_out)`.
+  }];
+  let arguments = (ins
+    DsaRandGenSeedType:$seed0,
+    DsaRandGenSeedType:$seed1,
+    I32Attr:$byte_count,
+    I16Attr:$fmt
+  );
+  let results = (outs
+    DsaRandGenOutType:$out,
+    DsaRandGenSeedType:$seed0_out,
+    DsaRandGenSeedType:$seed1_out
+  );
+  let assemblyFormat = [{
+    $seed0 `,` $seed1 attr-dict `:` type($seed0) `,` type($seed1)
+    `->` type($out) `,` type($seed0_out) `,` type($seed1_out)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// dsa.bitcast
+//===----------------------------------------------------------------------===//
+
+def Dsa_BitcastOp : Dsa_Op<"bitcast", [Pure]> {
+  let summary = "Same-nbytes type/shape reinterpret (vendor-neutral)";
+  let description = [{
+    Reinterpret `src` as `result` when both tensors have the same total bit
+    size.  Element type and/or shape may change (e.g. `tensor<Nx i64>` →
+    `tensor<(2N)x i32>`).  This is a pure view: no data movement.
+
+    Backends lower this to a zero-cost alias when possible (e.g. Tsingmicro
+    `mk.bitcast`); a portable fallback is `tensor.bitcast`.
+  }];
+  let arguments = (ins AnyRankedTensor:$src);
+  let results = (outs AnyRankedTensor:$result);
+  let assemblyFormat = [{
+    $src attr-dict `:` type($src) `->` type($result)
+  }];
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// dsa.extract_slice / dsa.insert_slice: strided tensor slice ops.
+// Mixed static/dynamic per-dim offsets follow the tensor.extract_slice
+// convention: `static_offsets` uses ShapedType::kDynamic as the sentinel for
+// positions whose runtime value is carried by the variadic `offsets` operands.
+// sizes/strides are always compile-time constants.
+//===----------------------------------------------------------------------===//
+
+def DsaSliceOffsetType : AnyTypeOf<[TT_Tensor, TT_Int]>;
+
+def Dsa_ExtractSliceOp : Dsa_Op<"extract_slice", [Pure]> {
+  let summary = "Extract a strided slice from a tl.tensor (mixed static/dynamic offsets, static sizes/strides)";
+  let arguments = (ins TT_Tensor:$src,
+                       Variadic<DsaSliceOffsetType>:$offsets,
+                       DenseI64ArrayAttr:$static_offsets,
+                       DenseI64ArrayAttr:$sizes,
+                       DenseI64ArrayAttr:$strides);
+  let results = (outs TT_Tensor:$result);
+}
+
+def Dsa_InsertSliceOp : Dsa_Op<"insert_slice", [Pure]> {
+  let summary = "Insert a strided slice into a tl.tensor (mixed static/dynamic offsets, static sizes/strides)";
+  let arguments = (ins TT_Tensor:$src,
+                       TT_Tensor:$tile,
+                       Variadic<DsaSliceOffsetType>:$offsets,
+                       DenseI64ArrayAttr:$static_offsets,
+                       DenseI64ArrayAttr:$sizes,
+                       DenseI64ArrayAttr:$strides);
+  let results = (outs TT_Tensor:$result);
 }
 
 #endif // TLE_DSA_OPS

--- a/third_party/tle/lib/Conversion/DsaToCore/DsaToCore.cpp
+++ b/third_party/tle/lib/Conversion/DsaToCore/DsaToCore.cpp
@@ -8,6 +8,7 @@
 #include "tle-dsa/Conversion/DsaToCore/DsaToCore.h"
 
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/Pass.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
@@ -45,17 +46,29 @@ struct DsaCopyToMemRefPattern : public OpRewritePattern<mlir::dsa::CopyOp> {
   }
 };
 
+// Portable fallback when a backend does not lower dsa.bitcast itself.
+struct DsaBitcastToTensorBitcastPattern
+    : public OpRewritePattern<mlir::dsa::BitcastOp> {
+  using OpRewritePattern::OpRewritePattern;
+  LogicalResult matchAndRewrite(mlir::dsa::BitcastOp op,
+                                PatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<tensor::BitcastOp>(op, op.getResult().getType(),
+                                                   op.getSrc());
+    return success();
+  }
+};
+
 struct DsaMemoryToCorePass
     : public PassWrapper<DsaMemoryToCorePass, OperationPass<ModuleOp>> {
   MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(DsaMemoryToCorePass)
   StringRef getArgument() const final { return "dsa-memory-to-core"; }
   StringRef getDescription() const final {
-    return "Lower dsa.alloc/copy to memref";
+    return "Lower dsa.alloc/copy/bitcast to memref/tensor core ops";
   }
   void runOnOperation() override {
     RewritePatternSet patterns(&getContext());
-    patterns.add<DsaAllocToMemRefPattern, DsaCopyToMemRefPattern>(
-        &getContext());
+    patterns.add<DsaAllocToMemRefPattern, DsaCopyToMemRefPattern,
+                 DsaBitcastToTensorBitcastPattern>(&getContext());
     if (failed(applyPatternsGreedily(getOperation(), std::move(patterns))))
       signalPassFailure();
   }

--- a/third_party/tle/lib/Dialect/IR/DsaDialect.cpp
+++ b/third_party/tle/lib/Dialect/IR/DsaDialect.cpp
@@ -7,6 +7,7 @@
 #include "tle-dsa/Dialect/IR/DsaDialect.h"
 
 #include "mlir/IR/DialectImplementation.h"
+#include "mlir/Support/LogicalResult.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 using namespace mlir;
@@ -37,3 +38,20 @@ void DsaDialect::registerTypes() {
 
 #define GET_TYPEDEF_CLASSES
 #include "tle-dsa/Dialect/IR/DsaOpsTypes.cpp.inc"
+
+LogicalResult mlir::dsa::BitcastOp::verify() {
+  auto srcTy = dyn_cast<RankedTensorType>(getSrc().getType());
+  auto dstTy = dyn_cast<RankedTensorType>(getResult().getType());
+  if (!srcTy || !dstTy)
+    return emitOpError("expects ranked tensor src/result");
+  auto srcElem = srcTy.getElementType();
+  auto dstElem = dstTy.getElementType();
+  if (!srcElem.isIntOrFloat() || !dstElem.isIntOrFloat())
+    return emitOpError("element types must be int or float");
+  int64_t srcBits = srcTy.getNumElements() * srcElem.getIntOrFloatBitWidth();
+  int64_t dstBits = dstTy.getNumElements() * dstElem.getIntOrFloatBitWidth();
+  if (srcBits != dstBits)
+    return emitOpError("src and result must have the same total bit size, got ")
+           << srcBits << " vs " << dstBits;
+  return success();
+}

--- a/third_party/tle/python/triton_tle_dsa.cc
+++ b/third_party/tle/python/triton_tle_dsa.cc
@@ -23,6 +23,26 @@ using namespace mlir;
 
 namespace dsa = mlir::dsa;
 
+static llvm::SmallVector<Value> castDynOffsets(py::list dynOffsets) {
+  llvm::SmallVector<Value> dyn;
+  dyn.reserve(py::len(dynOffsets));
+  for (py::handle arg : dynOffsets)
+    dyn.push_back(py::cast<Value>(arg));
+  return dyn;
+}
+
+// Inject a three-operand dsa binary op builder: create_dsa_<name>(lhs, rhs,
+// out).
+template <typename DsaOpT>
+static void defBinaryOp(py::class_<TritonOpBuilder> &builderCls,
+                        const char *name) {
+  builderCls.def(
+      name, [](TritonOpBuilder &self, Value lhs, Value rhs, Value out) -> void {
+        self.getContext()->getOrLoadDialect<dsa::DsaDialect>();
+        self.getBuilder().create<DsaOpT>(self.getLastLoc(), lhs, rhs, out);
+      });
+}
+
 static void init_triton_tle_ir(py::module m) {
   (void)m;
   auto core_ir = py::module::import("triton._C.libtriton.ir");
@@ -97,6 +117,29 @@ static void init_triton_tle_ir(py::module m) {
           },
           py::arg("resultTy"), py::arg("src"), py::arg("shardId"),
           py::arg("scope") = py::none())
+      .def("create_dsa_to_tensor",
+           [](TritonOpBuilder &self, Type resultTy, Value src,
+              bool writable) -> Value {
+             self.getContext()->getOrLoadDialect<dsa::DsaDialect>();
+             auto &b = self.getBuilder();
+             auto writableAttr = b.getBoolAttr(writable);
+             auto op =
+                 self.create<dsa::ToTensorOp>(resultTy, src, writableAttr);
+             return op.getResult();
+           })
+      .def("create_dsa_to_buffer",
+           [](TritonOpBuilder &self, Value src, Value dst) -> void {
+             self.getContext()->getOrLoadDialect<dsa::DsaDialect>();
+             self.create<dsa::ToBufferOp>(src, dst);
+           });
+  // Three-operand binary arithmetic (out = lhs OP rhs).
+  defBinaryOp<dsa::AddOp>(builder_cls, "create_dsa_add");
+  defBinaryOp<dsa::SubOp>(builder_cls, "create_dsa_sub");
+  defBinaryOp<dsa::MulOp>(builder_cls, "create_dsa_mul");
+  defBinaryOp<dsa::MaximumOp>(builder_cls, "create_dsa_maximum");
+  defBinaryOp<dsa::MinimumOp>(builder_cls, "create_dsa_minimum");
+  defBinaryOp<dsa::DivOp>(builder_cls, "create_dsa_div");
+  builder_cls
       .def("create_dsa_distributed_barrier",
            [](TritonOpBuilder &self, const std::string &groupKind,
               const std::vector<int32_t> &groupShape,
@@ -136,7 +179,65 @@ static void init_triton_tle_ir(py::module m) {
                  builder.getI32IntegerAttr(axis), builder.getBoolAttr(reverse),
                  DenseI64ArrayAttr::get(ctx, shape),
                  builder.getI64IntegerAttr(pad));
+           })
+      .def("create_dsa_randgen",
+           [](TritonOpBuilder &self, Type outTy, Type seed0OutTy,
+              Type seed1OutTy, Value seed0, Value seed1, int32_t byteCount,
+              int16_t fmt) -> OpState {
+             self.getContext()->getOrLoadDialect<dsa::DsaDialect>();
+             auto &builder = self.getBuilder();
+             return builder.create<dsa::RandGenOp>(
+                 self.getLastLoc(), TypeRange{outTy, seed0OutTy, seed1OutTy},
+                 seed0, seed1, builder.getI32IntegerAttr(byteCount),
+                 builder.getI16IntegerAttr(fmt));
+           })
+      // Vendor-neutral same-nbytes type/shape reinterpret (e.g.
+      // i64[N]→i32[2N]). Backends lower this (Tsingmicro: mk.bitcast alias;
+      // others: tensor.bitcast).
+      .def("create_dsa_bitcast",
+           [](TritonOpBuilder &self, Type dstTy, Value src) -> Value {
+             self.getContext()->getOrLoadDialect<dsa::DsaDialect>();
+             return self.create<dsa::BitcastOp>(dstTy, src);
            });
+  builder_cls
+      .def(
+          "create_dsa_extract_slice",
+          [](TritonOpBuilder &self, Type resultTy, Value src,
+             const std::vector<int64_t> &staticOffsets, py::list dynOffsets,
+             const std::vector<int64_t> &sizes,
+             const std::vector<int64_t> &strides) -> Value {
+            self.getContext()->getOrLoadDialect<dsa::DsaDialect>();
+            auto &builder = self.getBuilder();
+            auto *ctx = builder.getContext();
+            auto dyn = castDynOffsets(dynOffsets);
+            auto op = self.create<dsa::ExtractSliceOp>(
+                resultTy, src, dyn, DenseI64ArrayAttr::get(ctx, staticOffsets),
+                DenseI64ArrayAttr::get(ctx, sizes),
+                DenseI64ArrayAttr::get(ctx, strides));
+            return op.getResult();
+          },
+          py::arg("resultTy"), py::arg("src"), py::arg("staticOffsets"),
+          py::arg("dynOffsets"), py::arg("sizes"), py::arg("strides"))
+      .def(
+          "create_dsa_insert_slice",
+          [](TritonOpBuilder &self, Type resultTy, Value src, Value tile,
+             const std::vector<int64_t> &staticOffsets, py::list dynOffsets,
+             const std::vector<int64_t> &sizes,
+             const std::vector<int64_t> &strides) -> Value {
+            self.getContext()->getOrLoadDialect<dsa::DsaDialect>();
+            auto &builder = self.getBuilder();
+            auto *ctx = builder.getContext();
+            auto dyn = castDynOffsets(dynOffsets);
+            auto op = self.create<dsa::InsertSliceOp>(
+                resultTy, src, tile, dyn,
+                DenseI64ArrayAttr::get(ctx, staticOffsets),
+                DenseI64ArrayAttr::get(ctx, sizes),
+                DenseI64ArrayAttr::get(ctx, strides));
+            return op.getResult();
+          },
+          py::arg("resultTy"), py::arg("src"), py::arg("tile"),
+          py::arg("staticOffsets"), py::arg("dynOffsets"), py::arg("sizes"),
+          py::arg("strides"));
 }
 
 // void init_triton_tle(py::module &&m, const char *submodule_name = nullptr) {

--- a/third_party/tsingmicro/backend/cpu_driver.py
+++ b/third_party/tsingmicro/backend/cpu_driver.py
@@ -6,6 +6,9 @@ import os, subprocess, tempfile
 import importlib.util
 import sysconfig
 
+import time
+
+import triton
 from pathlib import Path
 
 from triton.runtime.cache import get_cache_manager
@@ -351,6 +354,62 @@ class CPUUtils(object):
                 )
 
 
+class CPUDeviceInterface:
+
+    class HooksTimeAccessor:
+
+        def __init__(self, di):
+            self.di = di
+            self.record_idx = 0
+
+        def elapsed_time(self, end_event) -> float:
+            total_time = 0
+            for i in range(self.record_idx, end_event.record_idx):
+                total_time += self.di.kernel_times[i]
+            return total_time * 1000
+
+        def record(self):
+            self.record_idx = len(self.di.kernel_times)
+
+    class TimerEvent:
+
+        def __init__(self):
+            self.timer = 0
+
+        def elapsed_time(self, end_event) -> float:
+            return (end_event.timer - self.timer) * 1000
+
+        def record(self):
+            self.timer = time.perf_counter()
+
+    def __init__(self):
+        self.kernel_times = []
+        self.last_start = 0
+        self.use_hooks = False
+        self.__name__ = "cpu"  # Required by autotuner
+        triton.compiler.CompiledKernel.launch_enter_hook = None
+        triton.compiler.CompiledKernel.launch_exit_hook = None
+
+    def enable_hook_timing(self):
+        self.use_hooks = True
+        triton.compiler.CompiledKernel.launch_enter_hook = lambda arg: self._enter_hook()
+        triton.compiler.CompiledKernel.launch_exit_hook = lambda arg: self._exit_hook()
+
+    def synchronize(self):
+        pass
+
+    def _enter_hook(self):
+        self.last_start = time.perf_counter()
+
+    def _exit_hook(self):
+        self.kernel_times.append(time.perf_counter() - self.last_start)
+
+    def Event(self, enable_timing=True):
+        if self.use_hooks:
+            return CPUDeviceInterface.HooksTimeAccessor(self)
+        return CPUDeviceInterface.TimerEvent()
+
+
 class CPUDriver(DriverBase):
 
     def __init__(self):
@@ -382,6 +441,26 @@ class CPUDriver(DriverBase):
 
     def get_current_target(self):
         return GPUTarget("cpu", 0, 0)
+
+    def get_active_torch_device(self):
+        import torch
+        return torch.device("cpu")
+
+    def get_benchmarker(self):
+        from triton.testing import do_bench
+        return do_bench
+
+    def get_device_interface(self):
+        return CPUDeviceInterface()
+
+    def get_empty_cache_for_benchmark(self):
+        import torch
+        # Typical LLC size for high-end server CPUs ~400 MB
+        cache_size = 512 * 1024 * 1024
+        return torch.empty(int(cache_size // 4), dtype=torch.int, device='cpu')
+
+    def clear_cache(self, cache):
+        cache.zero_()
 
     def assemble_tensormap_to_arg(self, tensormaps_info, args):
         return args

--- a/third_party/tsingmicro/backend/driver.cpp
+++ b/third_party/tsingmicro/backend/driver.cpp
@@ -16,6 +16,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "tx_runtime.h"
+
 static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
   // Extract device properties
   // Note: We're mapping Tx81 properties to fields expected by Triton
@@ -34,6 +36,9 @@ static PyObject *getDeviceProperties(PyObject *self, PyObject *args) {
                        mem_bus_width);
 }
 
+// Load kernel ELF once via txModuleLoad and return a persistent function
+// handle. Callers then launch with txLaunchKernel(handle, ...) instead of
+// re-passing the ELF blob through txLaunchKernelGGL on every launch.
 static PyObject *loadBinary(PyObject *self, PyObject *args) {
   const char *name;
   const char *data;
@@ -41,10 +46,52 @@ static PyObject *loadBinary(PyObject *self, PyObject *args) {
   int shared;
   int device;
 
+  if (!PyArg_ParseTuple(args, "ss#ii", &name, &data, &data_size, &shared,
+                        &device)) {
+    return NULL;
+  }
+  if (data_size <= 0) {
+    PyErr_SetString(PyExc_ValueError, "empty kernel binary");
+    return NULL;
+  }
+
+  txModule_t mod = NULL;
+  txFunction_t fun = NULL;
   int32_t n_regs = 256;
   int32_t n_spills = 0;
-  // Return values to Python including module, function, n_regs, n_spills
-  return Py_BuildValue("(KKii)", "module {}", "void @add_kernel() {}", n_regs,
+  txError_t st;
+
+  Py_BEGIN_ALLOW_THREADS;
+  st = txSetDevice(device);
+  if (st == TX_SUCCESS) {
+    // txModuleLoad may read asynchronously; keep a stable copy for the call.
+    char *elf_copy = (char *)malloc((size_t)data_size);
+    if (!elf_copy) {
+      st = TX_MEM_MALLOC_FAIL;
+    } else {
+      memcpy(elf_copy, data, (size_t)data_size);
+      st = txModuleLoad(&mod, elf_copy, (uint32_t)data_size);
+      // Elf buffer only needs to live until ModuleLoad returns.
+      free(elf_copy);
+      if (st == TX_SUCCESS) {
+        st = txModuleGetFunction(&fun, mod, name);
+        if (st != TX_SUCCESS) {
+          txModuleUnload(mod);
+          mod = NULL;
+          fun = NULL;
+        }
+      }
+    }
+  }
+  Py_END_ALLOW_THREADS;
+
+  if (st != TX_SUCCESS) {
+    return PyErr_Format(PyExc_RuntimeError,
+                        "txModuleLoad/GetFunction('%s') failed: error=%d", name,
+                        (int)st);
+  }
+
+  return Py_BuildValue("(KKii)", (uint64_t)mod, (uint64_t)fun, n_regs,
                        n_spills);
 }
 

--- a/third_party/tsingmicro/backend/driver.py
+++ b/third_party/tsingmicro/backend/driver.py
@@ -5,6 +5,7 @@
 # file above.
 #
 import hashlib
+import logging
 import tempfile
 import os
 import subprocess
@@ -288,10 +289,12 @@ static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
         if (!PyLong_Check(ret)) {{
             PyErr_SetString(PyExc_TypeError, "data_ptr method of Pointer object must return 64-bit int");
             ptr_info.valid = false;
+            Py_DECREF(ret);
             return ptr_info;
         }}
         ptr_info.dev_ptr = (void*) PyLong_AsLongLong(ret);
         if(!ptr_info.dev_ptr) {{
+            Py_DECREF(ret);
             return ptr_info;
         }}
         Py_DECREF(ret);  // Thanks ChatGPT!
@@ -567,6 +570,7 @@ struct Launch_args {{
     int launch_count = 0;
     std::vector<KernelArg> kargs;
     txStream_t stream = nullptr;
+    uint64_t function = 0;  // txFunction_t from txModuleGetFunction (0 → GGL fallback)
     int log_level = simple_logger::ERROR;
     LaunchRes result;
 }};
@@ -803,11 +807,22 @@ void dump_kernel_args(Launch_args &l_args) {{
 }}
 
 static bool set_device_id(int device_id) {{
+    // Skip redundant txSetDevice when device is unchanged (common hot path).
+    static thread_local int tls_device = -1;
+    if (tls_device == device_id) {{
+        return true;
+    }}
     if (txSetDevice(device_id) != TX_SUCCESS) {{
         PyErr_SetString(PyExc_RuntimeError, "Failed to set device");
         return false;
     }}
+    tls_device = device_id;
     return true;
+}}
+
+static bool force_ggl_launch() {{
+    const char* env = std::getenv("TXDA_LAUNCH_VIA_GGL");
+    return env != nullptr && (env[0] == '1' || env[0] == 'y' || env[0] == 'Y');
 }}
 
 static void _launch(Launch_args &l_args) {{
@@ -823,17 +838,9 @@ static void _launch(Launch_args &l_args) {{
         dump_kernel_args(l_args);
     }}
 
-    // TODO::mv
-    uint64_t kernel_len = 0;
-    void* kernel_ptr = nullptr;
-    int ret = read_bin_file(l_args.kernel_file, &kernel_ptr, &kernel_len);
-    if (ret != 0 || kernel_ptr == nullptr) {{
-        PyErr_SetString(PyExc_RuntimeError, "Failed to read kernel so");
-        return;
-    }}
-
-    // Allocate the device memory for all kernel arguments
+    // Flatten kernel args once for either launch path.
     std::vector<uint64_t> rtKargs;
+    rtKargs.reserve(l_args.kargs.size() * 2 + 6);
     for (KernelArg& karg : l_args.kargs) {{
         if (karg.data_type == POINT) {{
             rtKargs.push_back(1);
@@ -848,6 +855,11 @@ static void _launch(Launch_args &l_args) {{
     rtKargs.push_back(0);
     rtKargs.push_back(0);
     rtKargs.push_back(0);
+
+    dim3 gridDim({{(uint32_t)l_args.gridX, (uint32_t)l_args.gridY, (uint32_t)l_args.gridZ}});
+    dim3 blockDim({{1u, 1u, 1u}});
+    void* arg_ptr = rtKargs.empty() ? nullptr : (void*)(&rtKargs[0]);
+    uint32_t arg_bytes = (uint32_t)(rtKargs.size() * sizeof(uint64_t));
 
 #ifdef ENABLE_PROFILING
     static int run_count = 0;
@@ -870,10 +882,37 @@ static void _launch(Launch_args &l_args) {{
         _prof_token = resolve_tsm_prof_begin();
     }}
 #endif
-    if (txLaunchKernelGGL(l_args.kernel_fun_name, (uint64_t)kernel_ptr, kernel_len,
-        dim3({{(uint32_t)l_args.gridX, (uint32_t)l_args.gridY, (uint32_t)l_args.gridZ}}), dim3({{1u, 1u, 1u}}),
-        (void*)(&rtKargs[0]), rtKargs.size()*sizeof(uint64_t), 0, l_args.stream) != TX_SUCCESS){{
-        PyErr_SetString(PyExc_RuntimeError, "Failed to txLaunchKernelGGL");
+
+    // Fast path: launch by pre-loaded module function handle (txModuleLoad once
+    // in load_binary). Avoids re-passing the ELF blob via txLaunchKernelGGL.
+    // Fallback: TXDA_LAUNCH_VIA_GGL=1 or missing handle → legacy GGL path.
+    txError_t launch_st = TX_SUCCESS;
+    const bool use_handle = (l_args.function != 0) && !force_ggl_launch();
+    if (use_handle) {{
+        Py_BEGIN_ALLOW_THREADS;
+        launch_st = txLaunchKernel((txFunction_t)l_args.function, gridDim, blockDim,
+                                   arg_ptr, arg_bytes, 0, l_args.stream);
+        Py_END_ALLOW_THREADS;
+        if (launch_st != TX_SUCCESS) {{
+            PyErr_Format(PyExc_RuntimeError, "Failed to txLaunchKernel (err=%d)", (int)launch_st);
+            return;
+        }}
+    }} else {{
+        uint64_t kernel_len = 0;
+        void* kernel_ptr = nullptr;
+        int ret = read_bin_file(l_args.kernel_file, &kernel_ptr, &kernel_len);
+        if (ret != 0 || kernel_ptr == nullptr) {{
+            PyErr_SetString(PyExc_RuntimeError, "Failed to read kernel so");
+            return;
+        }}
+        Py_BEGIN_ALLOW_THREADS;
+        launch_st = txLaunchKernelGGL(l_args.kernel_fun_name, (uint64_t)kernel_ptr, kernel_len,
+            gridDim, blockDim, arg_ptr, arg_bytes, 0, l_args.stream);
+        Py_END_ALLOW_THREADS;
+        if (launch_st != TX_SUCCESS) {{
+            PyErr_SetString(PyExc_RuntimeError, "Failed to txLaunchKernelGGL");
+            return;
+        }}
     }}
     const char* env = std::getenv("TXDA_LAUNCH_KERNEL_SYNC");
     if (env != nullptr && std::string(env) == "1") {{
@@ -910,15 +949,11 @@ typedef struct _DevicePtrInfo {{
 
 // Function to get tensor size using untyped_storage if available
 static inline size_t getTensorSize(PyObject *obj) {{
-    // First try to get size via untyped_storage attribute (newer PyTorch versions)
-
-
     // Final fallback: calculate size from numel() * element_size()
     PyObject *numel_method = PyObject_GetAttrString(obj, "numel");
     PyObject *element_size_method = PyObject_GetAttrString(obj, "element_size");
 
     if (numel_method && element_size_method) {{
-        fflush(stdout);
         PyObject *empty_tuple1 = PyTuple_New(0);
         PyObject *empty_tuple2 = PyTuple_New(0);
         PyObject *numel_obj = PyObject_Call(numel_method, empty_tuple1, NULL);
@@ -946,7 +981,6 @@ static inline size_t getTensorSize(PyObject *obj) {{
         if (element_size_method) Py_DECREF(element_size_method);
     }}
 
-    fflush(stdout);
     return 0;  // Return 0 if unable to determine size
 }}
 
@@ -956,7 +990,6 @@ static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
     ptr_info.valid = true;
     ptr_info.size = 0;  // Initialize size
 
-    fflush(stdout);
     if (PyLong_Check(obj)) {{
         ptr_info.dev_ptr = (void*) PyLong_AsLongLong(obj);
         logger.log(simple_logger::DEBUG, "PyLong_AsLongLong %p\\n", ptr_info.dev_ptr);
@@ -966,14 +999,11 @@ static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
     if (obj == Py_None) {{
         // valid nullptr
         logger.log(simple_logger::DEBUG, "Py_None\\n");
-        fflush(stdout);
         return ptr_info;
     }}
 
     PyObject *ptr = PyObject_GetAttrString(obj, "data_ptr");
     if(ptr){{
-        fflush(stdout);
-
         PyObject *empty_tuple = PyTuple_New(0);
         PyObject *ret = PyObject_Call(ptr, empty_tuple, NULL);
         Py_DECREF(empty_tuple);
@@ -982,20 +1012,14 @@ static inline DevicePtrInfo getPointer(PyObject *obj, int idx) {{
             PyErr_SetString(PyExc_TypeError, "data_ptr method of Pointer object must return 64-bit int");
             logger.log(simple_logger::ERROR, "data_ptr method of Pointer object must return 64-bit int\\n");
             ptr_info.valid = false;
-            fflush(stdout);
+            Py_DECREF(ret);
             return ptr_info;
         }}
         ptr_info.dev_ptr = (void*) PyLong_AsLongLong(ret);
-        if(!ptr_info.dev_ptr) {{
-            fflush(stdout);
-            return ptr_info;
-        }}
-        Py_DECREF(ret);  // Thanks ChatGPT!
+        Py_DECREF(ret);
 
-        // Get tensor size using the new function
-        ptr_info.size = getTensorSize(obj);
-        fflush(stdout);
-
+        // Size is only needed for debug dumps; skip hot-path Python calls.
+        // ptr_info.size stays 0 for the launch path (rtKargs never uses it).
         return ptr_info;
     }}
     std::string error_msg = "Pointer argument must be either uint64 or have data_ptr method\\n";
@@ -1063,6 +1087,7 @@ static PyObject* launch(PyObject* self, PyObject* args) {{
 
     logger.setLogLevel((simple_logger::LogLevel)l_args.log_level);
     l_args.stream = (txStream_t)_stream;
+    l_args.function = _function;
 
     //{' '.join([f"l_args.kargs.emplace_back(_arg{i}, PyObject_Size(_arg{i})*4);" if ty[0]=="*" else f"l_args.kargs.emplace_back(*(uint64_t*)&_arg{i}, sizeof(_arg{i}));" for i, ty in signature.items() if ty != "constexpr"])}
     // {' '.join([f"l_args.kargs.emplace_back(extractTensor(_arg{i}), getTensorStorageSize(_arg{i}));"
@@ -1209,13 +1234,16 @@ class TXDALauncher(object):
         _launch_counter += 1
         device_id = torch.txda.current_device()
         log_level = logger_to_custom_level_number(logger)
-        logger.info(f"{self.func_name} launch card:{device_id} count:{_launch_counter} begin")
+        # Avoid f-string work when log level is above INFO (default: ERROR).
+        if logger.isEnabledFor(logging.INFO):
+            logger.info("%s launch card:%s count:%s begin", self.func_name, device_id, _launch_counter)
         launchRes = self.launch(device_id, self.metadata.so_key, self.metadata.kernel_path, self.func_name,
                                 txda_tools.is_dump_args_profile(), txda_tools.get_dump_dir(), log_level,
                                 _launch_counter, gridX, gridY, gridZ, stream, function, *args, **kwargs)
-        logger.info(f"{self.func_name} launch card:{device_id} count:{_launch_counter} end")
+        if logger.isEnabledFor(logging.INFO):
+            logger.info("%s launch card:%s count:%s end", self.func_name, device_id, _launch_counter)
         if launchRes.res != 0:
-            logger.error(f"launch error code:{launchRes.res}")
+            logger.error("launch error code:%s", launchRes.res)
         global _last_launch_res
         _last_launch_res = launchRes
         return launchRes

--- a/third_party/tsingmicro/crt/lib/Tx81/randgen.c
+++ b/third_party/tsingmicro/crt/lib/Tx81/randgen.c
@@ -25,8 +25,11 @@ void __RandGen(uint64_t *src0, uint64_t *src1, uint64_t *dst0, uint64_t *dst1,
                              }};
   ;
 
-  cmd->RandGen(&inst, *src0, *src1, *dst0, *dst1, *dst2, src_elem_num,
-               (Data_Format)fmt);
+  // Match other CRT peri wrappers: pointer args are SPM addresses, not
+  // pointers-to-addresses. Hardware/sim interpret src_elem_num as byte count
+  // (must be a multiple of 128); each 128B chunk yields 16 uint64 values.
+  cmd->RandGen(&inst, (uint64_t)src0, (uint64_t)src1, (uint64_t)dst0,
+               (uint64_t)dst1, (uint64_t)dst2, src_elem_num, (Data_Format)fmt);
 
   // Dispatch the command to accelerator
   RcsExecute(&inst);

--- a/third_party/tsingmicro/examples/bare_matmul_autotune.py
+++ b/third_party/tsingmicro/examples/bare_matmul_autotune.py
@@ -15,26 +15,41 @@ DEVICE = triton.runtime.driver.active.get_active_torch_device()
 def prune_invalid_configs(configs, named_args, **kwargs):
     """过滤掉会导致 tensor 过大的配置"""
     MAX_NUMEL = 1048576
+    m = named_args.get("M")
+    n = named_args.get("N")
+    k = named_args.get("K")
     valid_configs = []
     for config in configs:
         block_size = config.kwargs.get("BLOCK_SIZE", 64)
-        # 检查 2D tensor 大小
-        if block_size * block_size <= MAX_NUMEL:
-            valid_configs.append(config)
+        if block_size * block_size > MAX_NUMEL:
+            continue
+        # Kernel has no boundary mask; BLOCK_SIZE must not exceed the tensor.
+        if m is not None and block_size > m:
+            continue
+        if n is not None and block_size > n:
+            continue
+        if k is not None and block_size > k:
+            continue
+        valid_configs.append(config)
     return valid_configs if valid_configs else [configs[0]]
 
 
 @triton.autotune(
     configs=[
-        triton.Config(kwargs={"BLOCK_SIZE": 4096}, num_stages=1, num_warps=32),
-        triton.Config(kwargs={"BLOCK_SIZE": 2048}, num_stages=1, num_warps=32),
-        triton.Config(kwargs={"BLOCK_SIZE": 1024}, num_stages=1, num_warps=32),
-        triton.Config(kwargs={"BLOCK_SIZE": 512}, num_stages=1, num_warps=32),
-        triton.Config(kwargs={"BLOCK_SIZE": 256}, num_stages=1, num_warps=32),
-        triton.Config(kwargs={"BLOCK_SIZE": 128}, num_stages=1, num_warps=32),
-        triton.Config(kwargs={"BLOCK_SIZE": 64}, num_stages=1, num_warps=16),
-        triton.Config(kwargs={"BLOCK_SIZE": 64}, num_stages=1, num_warps=32),
-    ], key=["M", "N", "K"], prune_configs_by={"early_config_prune": prune_invalid_configs}, warmup=25, rep=6000)
+        triton.Config(kwargs={"BLOCK_SIZE": 4096}, num_stages=2, num_warps=1),
+        triton.Config(kwargs={"BLOCK_SIZE": 2048}, num_stages=2, num_warps=1),
+        triton.Config(kwargs={"BLOCK_SIZE": 1024}, num_stages=2, num_warps=1),
+        triton.Config(kwargs={"BLOCK_SIZE": 512}, num_stages=2, num_warps=1),
+        triton.Config(kwargs={"BLOCK_SIZE": 256}, num_stages=2, num_warps=1),
+        triton.Config(kwargs={"BLOCK_SIZE": 128}, num_stages=2, num_warps=1),
+        triton.Config(kwargs={"BLOCK_SIZE": 64}, num_stages=2, num_warps=1),
+        triton.Config(kwargs={"BLOCK_SIZE": 64}, num_stages=2, num_warps=1),
+    ],
+    key=["M", "N", "K"],
+    prune_configs_by={"early_config_prune": prune_invalid_configs},
+    warmup=1,
+    rep=1,
+)
 @triton.jit
 def bare_matmul(X, Y, Z, M, N, K, BLOCK_SIZE: tl.constexpr):
     pid_x = tl.program_id(0)  # block row id
@@ -53,17 +68,29 @@ def bare_matmul(X, Y, Z, M, N, K, BLOCK_SIZE: tl.constexpr):
 
 # @benchmark.measure()
 def bench_matmul(M, N, K):
-    device = 'cpu'
     dtype = torch.float32
     a = torch.randint(0, 10, (M, K), dtype=torch.int32).to(dtype)
     b = torch.randint(0, 10, (K, N), dtype=torch.int32).to(dtype)
-    c = torch.empty((M, N), device=device, dtype=dtype)
 
+    # CPU: a, b stay on host
+    c_ref = torch.matmul(a, b)
+
+    # TX81: H2D, launch, sync, D2H
+    a_dev = a.to(DEVICE)
+    b_dev = b.to(DEVICE)
+    c_dev = torch.empty((M, N), device=DEVICE, dtype=dtype)
     grid = lambda meta: (triton.cdiv(M, meta['BLOCK_SIZE']), triton.cdiv(N, meta['BLOCK_SIZE']))
-    bare_matmul[grid](a, b, c, M, N, K)
+    bare_matmul[grid](a_dev, b_dev, c_dev, M, N, K)
+    torch.txda.synchronize()
+    c_act = c_dev.cpu()
 
     print(bare_matmul.best_config)
+    print(f"dev sample[:4,:4]=\n{c_act[:4, :4]}")
+    print(f"cpu sample[:4,:4]=\n{c_ref[:4, :4]}")
+    print(f"max_abs_diff={(c_act - c_ref).abs().max().item()}")
+    torch.testing.assert_close(c_act, c_ref, atol=1e-2, rtol=1e-2)
+    print("allclose PASS")
 
 
 if __name__ == "__main__":
-    bench_matmul(16, 16, 16)
+    bench_matmul(64, 64, 64)

--- a/third_party/tsingmicro/examples/conftest.py
+++ b/third_party/tsingmicro/examples/conftest.py
@@ -2,7 +2,7 @@ import pytest
 import os
 import tempfile
 import triton
-from triton.backends.ztc.driver import CPUDriver
+from triton.backends.tsingmicro.cpu_driver import CPUDriver
 
 triton.runtime.driver.set_active(CPUDriver())
 

--- a/third_party/tsingmicro/examples/test_early_return.py
+++ b/third_party/tsingmicro/examples/test_early_return.py
@@ -3,7 +3,7 @@ import torch
 import triton
 import triton.language as tl
 
-from triton.backends.ztc.driver import CPUDriver
+from triton.backends.tsingmicro.cpu_driver import CPUDriver
 
 
 @triton.jit

--- a/third_party/tsingmicro/examples/test_mask.py
+++ b/third_party/tsingmicro/examples/test_mask.py
@@ -3,7 +3,7 @@ import torch
 import triton
 import triton.language as tl
 
-from triton.backends.ztc.driver import CPUDriver
+from triton.backends.tsingmicro.cpu_driver import CPUDriver
 
 
 def test_mask(device):

--- a/third_party/tsingmicro/examples/test_nested_loops.py
+++ b/third_party/tsingmicro/examples/test_nested_loops.py
@@ -2,7 +2,7 @@ import torch
 
 import triton
 from triton.backends.compiler import GPUTarget
-from triton.backends.ztc.driver import CPUDriver
+from triton.backends.tsingmicro.cpu_driver import CPUDriver
 import triton.language as tl
 
 

--- a/third_party/tsingmicro/examples/test_sign_extend.py
+++ b/third_party/tsingmicro/examples/test_sign_extend.py
@@ -4,7 +4,7 @@ import triton
 
 import triton.language as tl
 
-from triton.backends.ztc.driver import CPUDriver
+from triton.backends.tsingmicro.cpu_driver import CPUDriver
 
 
 @triton.jit

--- a/third_party/tsingmicro/examples/test_tensor_index_iterargs.py
+++ b/third_party/tsingmicro/examples/test_tensor_index_iterargs.py
@@ -3,7 +3,7 @@ import torch
 import triton
 import triton.language as tl
 
-from triton.backends.ztc.driver import CPUDriver
+from triton.backends.tsingmicro.cpu_driver import CPUDriver
 
 
 def test_tensor_indices_nested_with_mask(device):

--- a/third_party/tsingmicro/include/magic-kernel/Dialect/IR/MagicKernelOps.td
+++ b/third_party/tsingmicro/include/magic-kernel/Dialect/IR/MagicKernelOps.td
@@ -477,6 +477,29 @@ def CumsumOp : MKOp<"cumsum", [DestinationStyleOpInterface]> {
   }];
 }
 
+def RandGenOp : MKOp<"randgen", [DestinationStyleOpInterface]> {
+  let summary = "hardware xorshift128+ PRNG lowered to tx.randgen / __RandGen";
+
+  let arguments = (
+    ins
+    TensorOrMemref:$seed0,
+    TensorOrMemref:$seed1,
+    Arg<TensorOrMemref, "random output", [MemWrite]>:$out,
+    Arg<TensorOrMemref, "updated seed0", [MemWrite]>:$seed0_out,
+    Arg<TensorOrMemref, "updated seed1", [MemWrite]>:$seed1_out,
+    I32Attr:$byte_count,
+    I16Attr:$fmt
+  );
+
+  let results = (outs Variadic<TensorOrMemref>:$result);
+
+  let extraClassDeclaration = [{
+    MutableOperandRange getDpsInitsMutable() {
+      return MutableOperandRange(getOperation(), /*start=*/2, /*count=*/3);
+    }
+  }];
+}
+
 // =============================================================================
 // Unary/Binary/Ternary Element-wise Math Ops
 // =============================================================================

--- a/third_party/tsingmicro/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.h
+++ b/third_party/tsingmicro/include/triton-shared/Conversion/TritonArithToLinalg/ConversionPatterns.h
@@ -359,7 +359,7 @@ public:
                                                   loc, rewriter);
       auto zeroMap = AffineMap::getConstantMap(0, rewriter.getContext());
       auto loadOp = rewriter.create<affine::AffineLoadOp>(
-          op.getLoc(), sMemRef, zeroMap, std::nullopt);
+          op.getLoc(), sMemRef, zeroMap, ValueRange{});
       rewriter.replaceOp(op, loadOp.getResult());
       return success();
     }
@@ -519,7 +519,7 @@ struct StoreConverter : public OpConversionPattern<triton::StoreOp> {
           PtrAnalysis::getScalarMemRef(op.getPtr(), ptr, loc, rewriter);
       auto zeroMap = AffineMap::getConstantMap(0, rewriter.getContext());
       rewriter.create<affine::AffineStoreOp>(loc, val, sMemRef, zeroMap,
-                                             std::nullopt);
+                                             ValueRange{});
       rewriter.eraseOp(op);
       return success();
     }
@@ -926,8 +926,21 @@ struct BitcastConverter : public OpConversionPattern<triton::BitcastOp> {
     if (isa<PointerType>(inputType) || isa<PointerType>(resultType)) {
       return success();
     }
+    // Same-bitwidth tensor bitcast is a pure type reinterpret on TX81.
+    // Emit mk.bitcast (buffer alias) instead of arith.bitcast, which would
+    // otherwise lower through linalg.generic → scf.for load/bitcast/store.
+    if (auto inRTT = dyn_cast<RankedTensorType>(inputType)) {
+      if (auto outRTT = dyn_cast<RankedTensorType>(resultType)) {
+        if (inRTT.getElementTypeBitWidth() == outRTT.getElementTypeBitWidth() &&
+            inRTT.getNumElements() == outRTT.getNumElements()) {
+          rewriter.replaceOpWithNewOp<mk::BitcastOp>(op, resultType,
+                                                     adaptor.getSrc());
+          return success();
+        }
+      }
+    }
     auto arithBitcast = rewriter.create<arith::BitcastOp>(
-        op.getLoc(), op.getType(), op.getOperand());
+        op.getLoc(), op.getType(), adaptor.getSrc());
 
     rewriter.replaceOp(op, arithBitcast.getResult());
     return success();

--- a/third_party/tsingmicro/include/tsingmicro-tx81/Dialect/IR/Tx81Ops.td
+++ b/third_party/tsingmicro/include/tsingmicro-tx81/Dialect/IR/Tx81Ops.td
@@ -1068,16 +1068,24 @@ def Lut32Op : Tx81Op<"lut32", []> {
 }
 
 def RandGenOp : Tx81Op<"randgen", []> {
-  let summary = "Generate random numbers using two 64-bit seeds";
+  let summary = "Hardware xorshift128+ PRNG (CGRA peri op)";
+
+  let description = [{
+    Generate random uint64 values from 16 parallel xorshift128+ streams.
+
+    `src0`/`src1` hold 16×uint64 seeds; `dst0`/`dst1` receive updated seeds;
+    `dst2` receives the random uint64 stream. `byte_count` is the output size
+    in bytes and must be a multiple of 128 (16 lanes × 8 bytes per step).
+  }];
 
   let arguments = (ins
-    UI64:$src0,          // The first random seed
-    UI64:$src1,          // The second random seed
-    UI64:$dst0,          // Store the first random seed
-    UI64:$dst1,          // Store the second random seed
-    UI64:$dst2,          // Random value
-    I32Attr:$elem_num,   // Number of random values
-    I16Attr:$fmt         // The date format of random value
+    MemRefOrInt:$src0,          // First seed vector address (16×u64)
+    MemRefOrInt:$src1,          // Second seed vector address (16×u64)
+    Arg<MemRefOrInt, "updated first seed", [MemWrite]>:$dst0,
+    Arg<MemRefOrInt, "updated second seed", [MemWrite]>:$dst1,
+    Arg<MemRefOrInt, "random output", [MemWrite]>:$dst2,
+    I32Attr:$byte_count,        // Output byte count (multiple of 128)
+    I16Attr:$fmt                // Data format (typically UINT64/INT64)
   );
 }
 

--- a/third_party/tsingmicro/lib/Conversion/LinalgToMK/LinalgToMK.cpp
+++ b/third_party/tsingmicro/lib/Conversion/LinalgToMK/LinalgToMK.cpp
@@ -1426,25 +1426,76 @@ struct DivFloatOpRewrite : public OpRewritePattern<linalg::GenericOp> {
 
     auto inputTensorType =
         dyn_cast<RankedTensorType>(op.getInputs()[0].getType());
-    auto rank = inputTensorType.getRank();
     auto outputTensorType =
         dyn_cast<RankedTensorType>(op.getOutputs()[0].getType());
-    auto empty = rewriter.create<tensor::EmptyOp>(
-        loc, inputTensorType.getShape(), inputTensorType.getElementType());
 
-    Value recip = rewriter
-                      .create<linalg::ReciprocalOp>(
-                          loc, inputTensorType, ValueRange{op.getInputs()[1]},
-                          ValueRange{empty})
-                      ->getResult(0);
+    // Regular (tensor) path: out = lhs / rhs  ->  recip(rhs) * lhs.
+    if (inputTensorType && outputTensorType) {
+      auto rank = inputTensorType.getRank();
+      auto empty = rewriter.create<tensor::EmptyOp>(
+          loc, inputTensorType.getShape(), inputTensorType.getElementType());
 
-    SmallVector<AffineMap, 3> binaryIndexingMaps(
-        3, rewriter.getMultiDimIdentityMap(rank));
-    SmallVector<utils::IteratorType, 6> iteratorTypes(
-        rank, utils::IteratorType::parallel);
-    rewriter.replaceOpWithNewOp<linalg::GenericOp>(
-        op, outputTensorType, ValueRange{op.getInputs()[0], recip},
-        ValueRange{empty}, binaryIndexingMaps, iteratorTypes,
+      Value recip = rewriter
+                        .create<linalg::ReciprocalOp>(
+                            loc, inputTensorType, ValueRange{op.getInputs()[1]},
+                            ValueRange{empty})
+                        ->getResult(0);
+
+      SmallVector<AffineMap, 3> binaryIndexingMaps(
+          3, rewriter.getMultiDimIdentityMap(rank));
+      SmallVector<utils::IteratorType, 6> iteratorTypes(
+          rank, utils::IteratorType::parallel);
+      rewriter.replaceOpWithNewOp<linalg::GenericOp>(
+          op, outputTensorType, ValueRange{op.getInputs()[0], recip},
+          ValueRange{empty}, binaryIndexingMaps, iteratorTypes,
+          [&](OpBuilder &b, Location loc, ValueRange args) {
+            auto mulOp = b.create<arith::MulFOp>(loc, args[0], args[1]);
+            if (rndModeAttr)
+              mulOp->setAttr("rnd_mode", rndModeAttr);
+            b.create<linalg::YieldOp>(loc, mulOp.getResult());
+          });
+
+      return success();
+    }
+
+    // DSA memref path (mode 0/1): out = lhs / rhs
+    //   -> scratch = recip(rhs); out = mul(lhs, scratch).
+    // A scratch buffer keeps the result correct even when out aliases an
+    // input. It is allocated here (this pass runs before
+    // spmd-allocate-shared-memory) so it receives an allocation.offset attr.
+    auto lhsTy = dyn_cast<MemRefType>(op.getInputs()[0].getType());
+    auto rhsTy = dyn_cast<MemRefType>(op.getInputs()[1].getType());
+    auto outTy = dyn_cast<MemRefType>(op.getOutputs()[0].getType());
+    if (!lhsTy || !rhsTy || !outTy)
+      return failure();
+
+    if (lhsTy.getShape() != rhsTy.getShape() ||
+        lhsTy.getShape() != outTy.getShape())
+      return op->emitRemark("dsa binary op shape mismatch between lhs/rhs/out");
+    if (lhsTy.getElementType() != rhsTy.getElementType() ||
+        lhsTy.getElementType() != outTy.getElementType())
+      return op->emitRemark(
+          "dsa binary op element type mismatch between lhs/rhs/out");
+
+    auto scratch = rewriter.create<memref::AllocOp>(loc, outTy);
+    auto scratchMemref = scratch.getResult();
+
+    rewriter.create<linalg::ReciprocalOp>(loc, TypeRange{},
+                                          ValueRange{op.getInputs()[1]},
+                                          ValueRange{scratchMemref});
+
+    auto rank = static_cast<int64_t>(lhsTy.getShape().size());
+    auto identityMap = rewriter.getMultiDimIdentityMap(rank);
+    SmallVector<AffineMap> indexingMaps = {identityMap, identityMap,
+                                           identityMap};
+    SmallVector<mlir::utils::IteratorType> iteratorTypes(
+        rank, mlir::utils::IteratorType::parallel);
+
+    rewriter.create<linalg::GenericOp>(
+        loc,
+        /*resultTensorTypes=*/TypeRange{},
+        ValueRange{op.getInputs()[0], scratchMemref},
+        ValueRange{op.getOutputs()[0]}, indexingMaps, iteratorTypes,
         [&](OpBuilder &b, Location loc, ValueRange args) {
           auto mulOp = b.create<arith::MulFOp>(loc, args[0], args[1]);
           if (rndModeAttr)
@@ -1452,6 +1503,7 @@ struct DivFloatOpRewrite : public OpRewritePattern<linalg::GenericOp> {
           b.create<linalg::YieldOp>(loc, mulOp.getResult());
         });
 
+    rewriter.eraseOp(op);
     return success();
   }
 
@@ -1476,8 +1528,14 @@ struct DivIntOpRewrite : public OpRewritePattern<linalg::GenericOp> {
 
     // FIXME: Canonicalize non-precision mode divint in linalg-to-mk, others
     // default to scf.for
+    // DSA memref-operand generics have no results and non-tensor operands;
+    // only handle tensor-form integer division here.
+    if (op.getNumResults() != 1)
+      return failure();
     auto resultTensorType =
         dyn_cast<RankedTensorType>(op.getResult(0).getType());
+    if (!resultTensorType)
+      return failure();
     SmallVector<Value> inputs(op.getInputs().begin(), op.getInputs().end());
 
     SmallVector<Value> outputs = {rewriter.create<tensor::EmptyOp>(
@@ -1840,6 +1898,11 @@ struct PowFOpRewrite : public OpRewritePattern<linalg::GenericOp> {
     if (regionOps.size() != 1 || !isa<math::PowFOp>(regionOps.front()))
       return failure();
 
+    // Skip DSA memref-operand generics (no results / non-tensor operands).
+    if (op->getResultTypes().empty() ||
+        !isa<RankedTensorType>(op->getResultTypes()[0]))
+      return failure();
+
     auto base = op.getInputs()[0];
     auto exponent = op.getInputs()[1];
     auto loc = op->getLoc();
@@ -1905,6 +1968,8 @@ struct MinMaxOpRewrite : public OpRewritePattern<linalg::GenericOp> {
     auto rhs = op.getInputs()[1];
 
     auto inputType = dyn_cast<RankedTensorType>(lhs.getType());
+    if (!inputType)
+      return failure();
     auto rank = inputType.getRank();
 
     auto inputTypeEmpty = rewriter.create<tensor::EmptyOp>(
@@ -2381,6 +2446,11 @@ struct CastElementwiseOpIOToFloatPattern
     auto inputs = op.getInputs();
     // NOTE: Output not always exist
     auto outputs = op.getOutputs();
+
+    // Skip DSA memref-operand generics: this pattern is tensor-only and uses
+    // hard casts (would assert on memref operand types).
+    if (outputs.empty() || !isa<RankedTensorType>(outputs[0].getType()))
+      return failure();
 
     if (SIToFPOpBuildFnMap.contains(OpName) &&
         !preservesIntegerPrecision(
@@ -4007,6 +4077,12 @@ public:
     if (!isa<arith::RemFOp>(bodyOp))
       return failure();
 
+    // Skip DSA memref-operand generics: buildLinalgElementwise hard-casts
+    // operands to RankedTensorType.
+    if (op.getInputs().empty() ||
+        !isa<RankedTensorType>(op.getInputs()[0].getType()))
+      return failure();
+
     return rewriteRemFOp(op, rewriter);
   }
 };
@@ -4118,6 +4194,38 @@ struct UIToFPViaI32Rewrite : public OpRewritePattern<linalg::GenericOp> {
         });
 
     rewriter.replaceOp(op, sitofpGeneric->getResult(0));
+    return success();
+  }
+};
+
+// Fallback: convert linalg.generic{arith.bitcast} (same bitwidth) into
+// mk.bitcast so bufferization aliases the buffer instead of emitting an
+// scf.for. The primary path already lowers same-bitwidth tt.bitcast →
+// mk.bitcast in TritonArithToLinalg (BitcastConverter in
+// ConversionPatterns.h); this pattern only catches residual generics that
+// still enter LinalgToMK (e.g. hand-written core IR or arith.bitcast that
+// slipped through ElementwiseToLinalg).
+struct BitcastGenericToMKBitcast : public OpRewritePattern<linalg::GenericOp> {
+  using OpRewritePattern<linalg::GenericOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(linalg::GenericOp op,
+                                PatternRewriter &rewriter) const override {
+    auto regionOps = triton::getRegionOps<linalg::GenericOp>(op);
+    if (regionOps.size() != 1 || !isa<arith::BitcastOp>(regionOps.front()))
+      return failure();
+    if (op.getNumDpsInputs() != 1 || op.getNumDpsInits() != 1)
+      return failure();
+
+    Value src = op.getInputs().front();
+    auto srcTy = dyn_cast<RankedTensorType>(src.getType());
+    auto dstTy = dyn_cast<RankedTensorType>(op.getResultTypes().front());
+    if (!srcTy || !dstTy)
+      return failure();
+    if (srcTy.getElementTypeBitWidth() != dstTy.getElementTypeBitWidth() ||
+        srcTy.getNumElements() != dstTy.getNumElements())
+      return failure();
+
+    rewriter.replaceOpWithNewOp<mk::BitcastOp>(op, dstTy, src);
     return success();
   }
 };
@@ -4508,7 +4616,8 @@ void mlir::triton::populateLinalgToMKTypeConversionPatterns(
       patterns.getContext(), precisionMode /* precisionMode */);
   patterns.add<CannonicalizeRedudantTypeConversion>(patterns.getContext());
   patterns.add<I1ExtSIOpRewrite, I1ExtUIOpRewrite, I1ToF32Rewrite,
-               FP32ToI1Rewrite, UIToFPViaI32Rewrite>(patterns.getContext());
+               FP32ToI1Rewrite, UIToFPViaI32Rewrite, BitcastGenericToMKBitcast>(
+      patterns.getContext());
   // TODO: if need precision mode
   patterns.add<CastArgMinMaxOpIOToFloatPattern<mk::ArgMaxOp>,
                CastArgMinMaxOpIOToFloatPattern<mk::ArgMinOp>>(

--- a/third_party/tsingmicro/lib/Conversion/MKToTx81/MKToTx81.cpp
+++ b/third_party/tsingmicro/lib/Conversion/MKToTx81/MKToTx81.cpp
@@ -1933,6 +1933,54 @@ struct MKCumsumOpConversion : public OpConversionPattern<mk::CumsumOp> {
   }
 };
 
+struct MKRandGenOpConversion : public OpConversionPattern<mk::RandGenOp> {
+  using OpConversionPattern<mk::RandGenOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(mk::RandGenOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    auto seed0Type = dyn_cast<MemRefType>(op.getSeed0().getType());
+    auto seed1Type = dyn_cast<MemRefType>(op.getSeed1().getType());
+    auto outType = dyn_cast<MemRefType>(op.getOut().getType());
+    auto seed0OutType = dyn_cast<MemRefType>(op.getSeed0Out().getType());
+    auto seed1OutType = dyn_cast<MemRefType>(op.getSeed1Out().getType());
+    if (!seed0Type || !seed1Type || !outType || !seed0OutType || !seed1OutType)
+      return rewriter.notifyMatchFailure(
+          op, "mk.randgen expects memref operands after bufferization");
+    if (seed0Type.getShape() != ArrayRef<int64_t>({16}) ||
+        seed1Type.getShape() != ArrayRef<int64_t>({16}))
+      return rewriter.notifyMatchFailure(
+          op, "mk.randgen seeds must have shape [16]");
+    if (!seed0Type.getElementType().isInteger(64) ||
+        !outType.getElementType().isInteger(64))
+      return rewriter.notifyMatchFailure(
+          op, "mk.randgen currently supports only i64 element type");
+
+    int32_t byteCount = op.getByteCount();
+    if (byteCount <= 0 || (byteCount % 128) != 0)
+      return rewriter.notifyMatchFailure(
+          op, "mk.randgen byte_count must be a positive multiple of 128");
+    if (outType.getNumElements() * 8 != byteCount)
+      return rewriter.notifyMatchFailure(
+          op, "mk.randgen out numel * 8 must equal byte_count");
+
+    Location loc = op.getLoc();
+    Value seed0Ptr = createAddressFromMemref(rewriter, loc, op.getSeed0());
+    Value seed1Ptr = createAddressFromMemref(rewriter, loc, op.getSeed1());
+    Value outPtr = createAddressFromMemref(rewriter, loc, op.getOut());
+    Value seed0OutPtr =
+        createAddressFromMemref(rewriter, loc, op.getSeed0Out());
+    Value seed1OutPtr =
+        createAddressFromMemref(rewriter, loc, op.getSeed1Out());
+
+    rewriter.replaceOpWithNewOp<tx::RandGenOp>(
+        op, TypeRange{}, seed0Ptr, seed1Ptr, seed0OutPtr, seed1OutPtr, outPtr,
+        rewriter.getI32IntegerAttr(byteCount),
+        rewriter.getI16IntegerAttr(op.getFmt()));
+    return success();
+  }
+};
+
 struct DistributeBarrierConversion
     : public OpConversionPattern<mk::DistributeBarrierOp> {
   using OpConversionPattern<mk::DistributeBarrierOp>::OpConversionPattern;
@@ -2508,6 +2556,7 @@ void mlir::triton::populateMKToTx81ConversionPatterns(
                MKReduceOpConversion<mk::ReduceMinOp, tx::ReduceMinOp>,
                MKReduceOpConversion<mk::ReduceSumOp, tx::ReduceSumOp>,
                MKCumsumOpConversion,
+               MKRandGenOpConversion,
                TransposeOpConversion,
                ReciprocalOpConversionPattern,
                LinalgFillOpConversion,

--- a/third_party/tsingmicro/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
+++ b/third_party/tsingmicro/lib/Conversion/StructuredToMemref/StructuredToMemref.cpp
@@ -1092,7 +1092,7 @@ private:
 
     // Wrap-around detection for contiguous dimension
     Value colSize = ofrToIndexValue(sizes[contiguousDim], loc, rewriter);
-    auto split = computeWrapAroundSplit(loc, rewriter, ptr.getMixedSizes(),
+    auto split = computeWrapAroundSplit(loc, rewriter, ptr.getMixedShape(),
                                         contiguousDim, offsetVal, colSize);
 
     SmallVector<OpFoldResult> zeroOffs(rank, rewriter.getIndexAttr(0));
@@ -1254,7 +1254,7 @@ private:
     auto sizes =
         mlir::getMixedValues(staticSizes, SmallVector<Value>{}, rewriter);
     auto ptrOffsets = ptr.getMixedOffsets();
-    auto ptrShapes = ptr.getMixedSizes();
+    auto ptrShapes = ptr.getMixedShape();
 
     // Check for wrap-around on contiguous dimension
     Value colSize = ofrToIndexValue(sizes[contiguousDim], loc, rewriter);

--- a/third_party/tsingmicro/lib/Conversion/TLEToMK/TLEToMK.cpp
+++ b/third_party/tsingmicro/lib/Conversion/TLEToMK/TLEToMK.cpp
@@ -13,6 +13,7 @@
 
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Bufferization/IR/Bufferization.h"
+#include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
 #include "mlir/IR/TypeUtilities.h"
@@ -25,6 +26,7 @@ using namespace mlir;
 using namespace triton;
 using namespace mk;
 using namespace tts;
+using namespace mlir::linalg;
 
 namespace {
 
@@ -470,6 +472,77 @@ struct DsaCumsumToMkPattern : public OpRewritePattern<mlir::dsa::CumsumOp> {
 };
 
 // ===----------------------------------------------------------------------===//
+// randgen
+// ===----------------------------------------------------------------------===//
+
+struct DsaRandGenToMkPattern : public OpRewritePattern<mlir::dsa::RandGenOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::dsa::RandGenOp op,
+                                PatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto seed0Ty = dyn_cast<RankedTensorType>(op.getSeed0().getType());
+    auto seed1Ty = dyn_cast<RankedTensorType>(op.getSeed1().getType());
+    auto outTy = dyn_cast<RankedTensorType>(op.getOut().getType());
+    auto seed0OutTy = dyn_cast<RankedTensorType>(op.getSeed0Out().getType());
+    auto seed1OutTy = dyn_cast<RankedTensorType>(op.getSeed1Out().getType());
+    if (!seed0Ty || !seed1Ty || !outTy || !seed0OutTy || !seed1OutTy)
+      return rewriter.notifyMatchFailure(
+          op, "dsa.randgen expects ranked tensor operands/results");
+    if (seed0Ty.getShape() != ArrayRef<int64_t>({16}) ||
+        seed1Ty.getShape() != ArrayRef<int64_t>({16}) ||
+        seed0OutTy.getShape() != ArrayRef<int64_t>({16}) ||
+        seed1OutTy.getShape() != ArrayRef<int64_t>({16}))
+      return rewriter.notifyMatchFailure(
+          op, "dsa.randgen seeds must have shape [16]");
+    if (!seed0Ty.getElementType().isInteger(64) ||
+        !seed1Ty.getElementType().isInteger(64) ||
+        !outTy.getElementType().isInteger(64))
+      return rewriter.notifyMatchFailure(
+          op, "dsa.randgen currently supports only i64 element type");
+
+    int32_t byteCount = op.getByteCount();
+    if (byteCount <= 0 || (byteCount % 128) != 0)
+      return rewriter.notifyMatchFailure(
+          op, "dsa.randgen byte_count must be a positive multiple of 128");
+    int64_t expectedOutElems = static_cast<int64_t>(byteCount) / 8;
+    if (outTy.getNumElements() != expectedOutElems)
+      return rewriter.notifyMatchFailure(
+          op, "dsa.randgen out numel must equal byte_count / 8");
+
+    auto outInit = rewriter.create<tensor::EmptyOp>(loc, outTy.getShape(),
+                                                    outTy.getElementType());
+    auto seed0Init = rewriter.create<tensor::EmptyOp>(
+        loc, seed0OutTy.getShape(), seed0OutTy.getElementType());
+    auto seed1Init = rewriter.create<tensor::EmptyOp>(
+        loc, seed1OutTy.getShape(), seed1OutTy.getElementType());
+
+    auto mkOp = rewriter.create<mk::RandGenOp>(
+        loc, TypeRange{outTy, seed0OutTy, seed1OutTy}, op.getSeed0(),
+        op.getSeed1(), outInit, seed0Init, seed1Init,
+        rewriter.getI32IntegerAttr(byteCount), op.getFmtAttr());
+
+    rewriter.replaceOp(op, mkOp->getResults());
+    return success();
+  }
+};
+
+// ===----------------------------------------------------------------------===//
+// dsa.bitcast → mk.bitcast (zero-cost SPM buffer alias)
+// ===----------------------------------------------------------------------===//
+
+struct DsaBitcastToMkPattern : public OpRewritePattern<mlir::dsa::BitcastOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::dsa::BitcastOp op,
+                                PatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<mk::BitcastOp>(op, op.getResult().getType(),
+                                               op.getSrc());
+    return success();
+  }
+};
+
+// ===----------------------------------------------------------------------===//
 // Remote pointers fallback (kept for edge cases)
 // ===----------------------------------------------------------------------===//
 
@@ -498,11 +571,257 @@ struct DsaRemotePointersToTritonPattern
   }
 };
 
+// dsa binary ops (add/sub/mul/maximum/minimum/div) → linalg.generic.
+// dsa.extract_slice / dsa.insert_slice -> tensor.extract_slice/insert_slice.
+// `static_offsets` uses ShapedType::kDynamic as a sentinel for positions whose
+// runtime value is carried by the variadic `offsets` operands.
+
+// Rebuild mixed static/dynamic per-dim offsets into OpFoldResult list.
+// Static -> i64 attr; dynamic -> extracted 0-d tensor (or scalar) cast to
+// index.
+static LogicalResult buildSliceOffsets(PatternRewriter &rewriter, Location loc,
+                                       ArrayRef<int64_t> staticOffsets,
+                                       ValueRange dynOffsets,
+                                       SmallVectorImpl<OpFoldResult> &offsets) {
+  unsigned dynIdx = 0;
+  for (int64_t s : staticOffsets) {
+    if (ShapedType::isDynamic(s)) {
+      if (dynIdx >= dynOffsets.size())
+        return failure();
+      Value v = dynOffsets[dynIdx++];
+      if (isa<RankedTensorType>(v.getType()))
+        v = rewriter.create<tensor::ExtractOp>(loc, v, ValueRange{});
+      if (!v.getType().isIndex())
+        v = rewriter.create<arith::IndexCastOp>(loc, rewriter.getIndexType(),
+                                                v);
+      offsets.push_back(v);
+    } else {
+      offsets.push_back(rewriter.getI64IntegerAttr(s));
+    }
+  }
+  return success(dynIdx == dynOffsets.size());
+}
+
+static void buildSliceSizesStrides(PatternRewriter &rewriter,
+                                   ArrayRef<int64_t> dims,
+                                   SmallVectorImpl<OpFoldResult> &result) {
+  for (int64_t d : dims)
+    result.push_back(rewriter.getI64IntegerAttr(d));
+}
+
+struct DsaExtractSliceToTensorSlicePattern
+    : public OpRewritePattern<mlir::dsa::ExtractSliceOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::dsa::ExtractSliceOp op,
+                                PatternRewriter &rewriter) const override {
+    auto srcTy = dyn_cast<RankedTensorType>(op.getSrc().getType());
+    if (!srcTy)
+      return failure();
+    auto resultTy = dyn_cast<RankedTensorType>(op.getResult().getType());
+    if (!resultTy)
+      return failure();
+
+    SmallVector<OpFoldResult> offsets;
+    if (failed(buildSliceOffsets(rewriter, op.getLoc(), op.getStaticOffsets(),
+                                 op.getOffsets(), offsets)))
+      return failure();
+    SmallVector<OpFoldResult> sizes, strides;
+    buildSliceSizesStrides(rewriter, op.getSizes(), sizes);
+    buildSliceSizesStrides(rewriter, op.getStrides(), strides);
+
+    rewriter.replaceOpWithNewOp<tensor::ExtractSliceOp>(
+        op, resultTy, op.getSrc(), offsets, sizes, strides);
+    return success();
+  }
+};
+
+struct DsaInsertSliceToTensorSlicePattern
+    : public OpRewritePattern<mlir::dsa::InsertSliceOp> {
+  using OpRewritePattern::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(mlir::dsa::InsertSliceOp op,
+                                PatternRewriter &rewriter) const override {
+    auto srcTy = dyn_cast<RankedTensorType>(op.getSrc().getType());
+    if (!srcTy)
+      return failure();
+
+    SmallVector<OpFoldResult> offsets;
+    if (failed(buildSliceOffsets(rewriter, op.getLoc(), op.getStaticOffsets(),
+                                 op.getOffsets(), offsets)))
+      return failure();
+    SmallVector<OpFoldResult> sizes, strides;
+    buildSliceSizesStrides(rewriter, op.getSizes(), sizes);
+    buildSliceSizesStrides(rewriter, op.getStrides(), strides);
+
+    rewriter.replaceOpWithNewOp<tensor::InsertSliceOp>(
+        op, op.getTile(), op.getSrc(), offsets, sizes, strides);
+    return success();
+  }
+};
+
+// Three-operand elementwise arithmetic on memrefs; benefit=4 fires before
+// DsaLocalLoadToMemrefPattern (benefit=3). MKToTx81 maps the arith op to
+// tx.*VV.
+template <typename DsaOpT, typename ArithOpT>
+struct DsaBinaryOpToLinalgPattern : public OpRewritePattern<DsaOpT> {
+  explicit DsaBinaryOpToLinalgPattern(MLIRContext *ctx)
+      : OpRewritePattern<DsaOpT>(ctx, /*benefit=*/4) {}
+
+  LogicalResult matchAndRewrite(DsaOpT op,
+                                PatternRewriter &rewriter) const override {
+    auto lhsTy = dyn_cast<MemRefType>(op.getLhs().getType());
+    auto rhsTy = dyn_cast<MemRefType>(op.getRhs().getType());
+    auto outTy = dyn_cast<MemRefType>(op.getOut().getType());
+    if (!lhsTy || !rhsTy || !outTy)
+      return failure();
+
+    if (lhsTy.getShape() != rhsTy.getShape() ||
+        lhsTy.getShape() != outTy.getShape())
+      return op->emitRemark("dsa binary op shape mismatch between lhs/rhs/out");
+    if (lhsTy.getElementType() != rhsTy.getElementType() ||
+        lhsTy.getElementType() != outTy.getElementType())
+      return op->emitRemark(
+          "dsa binary op element type mismatch between lhs/rhs/out");
+
+    Location loc = op.getLoc();
+    auto elemTy = lhsTy.getElementType();
+    auto rank = static_cast<int64_t>(lhsTy.getShape().size());
+    auto identityMap = rewriter.getMultiDimIdentityMap(rank);
+    SmallVector<AffineMap> indexingMaps = {identityMap, identityMap,
+                                           identityMap};
+    SmallVector<mlir::utils::IteratorType> iteratorTypes(
+        rank, mlir::utils::IteratorType::parallel);
+
+    auto linalgOp = rewriter.create<linalg::GenericOp>(
+        loc,
+        /*resultTensorTypes=*/TypeRange{}, ValueRange{op.getLhs(), op.getRhs()},
+        ValueRange{op.getOut()}, indexingMaps, iteratorTypes);
+
+    Block &block = linalgOp.getRegion().emplaceBlock();
+    block.addArgument(elemTy, loc);
+    block.addArgument(elemTy, loc);
+    block.addArgument(elemTy, loc);
+
+    {
+      OpBuilder::InsertionGuard guard(rewriter);
+      rewriter.setInsertionPointToStart(&block);
+      Value result = rewriter.create<ArithOpT>(loc, block.getArgument(0),
+                                               block.getArgument(1));
+      rewriter.create<linalg::YieldOp>(loc, result);
+    }
+
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+// dsa.to_tensor / dsa.to_buffer → bufferization ops.
+//   dsa.to_tensor (memref, writable) → bufferization.to_tensor
+//   dsa.to_buffer (tensor, memref)   → bufferization.to_memref + memref.copy
+
+/// dsa.to_tensor %src {writable} : memref<...> -> tensor<...>
+///     → bufferization.to_tensor %src {restrict, writable}
+struct DsaToTensorToBufferizationPattern
+    : public OpRewritePattern<mlir::dsa::ToTensorOp> {
+  explicit DsaToTensorToBufferizationPattern(MLIRContext *ctx)
+      : OpRewritePattern<mlir::dsa::ToTensorOp>(ctx, /*benefit=*/3) {}
+
+  LogicalResult matchAndRewrite(mlir::dsa::ToTensorOp op,
+                                PatternRewriter &rewriter) const override {
+    auto memrefTy = dyn_cast<MemRefType>(op.getSrc().getType());
+    if (!memrefTy)
+      return failure();
+
+    auto resultTy = dyn_cast<RankedTensorType>(op.getResult().getType());
+    if (!resultTy)
+      return failure();
+
+    auto tensorTy =
+        RankedTensorType::get(memrefTy.getShape(), memrefTy.getElementType());
+
+    // Shapes must agree (identity view).
+    if (tensorTy.getShape() != resultTy.getShape())
+      return op->emitRemark(
+          "dsa.to_tensor shape mismatch between memref and result tensor");
+
+    // Element types must match (no implicit cast support yet).
+    if (memrefTy.getElementType() != resultTy.getElementType())
+      return op->emitRemark("dsa.to_tensor element type mismatch between "
+                            "memref and result tensor");
+
+    auto toTensor = rewriter.create<bufferization::ToTensorOp>(
+        op.getLoc(), tensorTy, op.getSrc(),
+        /*restrict=*/true, /*writable=*/op.getWritable());
+    rewriter.replaceOp(op, toTensor.getResult());
+    return success();
+  }
+};
+
+/// dsa.to_buffer %src, %dst : tensor<...>, memref<...>
+///     → bufferization.to_memref %src : memref<...>; memref.copy %tmp, %dst
+struct DsaToBufferToBufferizationPattern
+    : public OpRewritePattern<mlir::dsa::ToBufferOp> {
+  explicit DsaToBufferToBufferizationPattern(MLIRContext *ctx)
+      : OpRewritePattern<mlir::dsa::ToBufferOp>(ctx, /*benefit=*/3) {}
+
+  LogicalResult matchAndRewrite(mlir::dsa::ToBufferOp op,
+                                PatternRewriter &rewriter) const override {
+    Value val = op.getSrc();
+    auto valTy = dyn_cast<RankedTensorType>(val.getType());
+    if (!valTy)
+      return failure();
+
+    auto destMemrefTy = dyn_cast<MemRefType>(op.getDst().getType());
+    if (!destMemrefTy)
+      return failure();
+
+    // Shapes must match.
+    if (valTy.getShape() != destMemrefTy.getShape())
+      return op->emitRemark(
+          "dsa.to_buffer shape mismatch between value tensor and SPM memref");
+
+    // Element types must match (no implicit cast support yet).
+    if (valTy.getElementType() != destMemrefTy.getElementType())
+      return op->emitRemark(
+          "dsa.to_buffer element type mismatch between value and SPM memref");
+
+    Location loc = op.getLoc();
+
+    // Materialise the tensor value as a memref, then copy into the SPM buffer.
+    auto srcMemrefTy =
+        MemRefType::get(valTy.getShape(), valTy.getElementType());
+    auto srcMemref =
+        rewriter.create<bufferization::ToMemrefOp>(loc, srcMemrefTy, val);
+    rewriter.create<memref::CopyOp>(loc, srcMemref, op.getDst());
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
 } // namespace
 
 void mlir::triton::populateTLEToMKConversionPatterns(
     RewritePatternSet &patterns) {
-  patterns.add<DsaCumsumToMkPattern>(patterns.getContext());
+  patterns
+      .add<DsaCumsumToMkPattern, DsaRandGenToMkPattern, DsaBitcastToMkPattern>(
+          patterns.getContext());
+
+  // Benefit 4: dsa binary arithmetic (add/sub/mul/max/min) → linalg.generic.
+  // Fires before DsaLocalLoadToMemrefPattern (benefit=3).
+  patterns
+      .add<DsaBinaryOpToLinalgPattern<mlir::dsa::AddOp, arith::AddFOp>,
+           DsaBinaryOpToLinalgPattern<mlir::dsa::SubOp, arith::SubFOp>,
+           DsaBinaryOpToLinalgPattern<mlir::dsa::MulOp, arith::MulFOp>,
+           DsaBinaryOpToLinalgPattern<mlir::dsa::MaximumOp, arith::MaximumFOp>,
+           DsaBinaryOpToLinalgPattern<mlir::dsa::MinimumOp, arith::MinimumFOp>,
+           DsaBinaryOpToLinalgPattern<mlir::dsa::DivOp, arith::DivFOp>>(
+          patterns.getContext());
+
+  // Benefit 3: dsa.to_tensor / dsa.to_buffer direct lowering.
+  patterns.add<DsaToTensorToBufferizationPattern,
+               DsaToBufferToBufferizationPattern>(patterns.getContext());
+
   // Highest benefit (3): local load/store → memref ops.
   // These MUST fire before any pattern that would produce !tt.ptr types.
   patterns.add<DsaLocalLoadToMemrefPattern, DsaLocalStoreToMemrefPattern>(
@@ -516,4 +835,7 @@ void mlir::triton::populateTLEToMKConversionPatterns(
   patterns
       .add<DsaRemotePointersToTritonPattern, DsaDistributedBarrierToMkPattern>(
           patterns.getContext());
+
+  patterns.add<DsaExtractSliceToTensorSlicePattern,
+               DsaInsertSliceToTensorSlicePattern>(patterns.getContext());
 }

--- a/third_party/tsingmicro/lib/Conversion/TLEToMK/TLEToMKPass.cpp
+++ b/third_party/tsingmicro/lib/Conversion/TLEToMK/TLEToMKPass.cpp
@@ -12,6 +12,7 @@
 #include "magic-kernel/Conversion/TLEToMK/TLEToMK.h"
 #include "magic-kernel/Dialect/IR/MagicKernelDialect.h"
 #include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "tle/include/tle-dsa/Dialect/IR/DsaDialect.h"
 #include "triton-shared/Dialect/TritonStructured/IR/TritonStructuredDialect.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
 
@@ -34,9 +35,9 @@ class TLEToMKPass : public TLEToMKBase<TLEToMKPass> {
 public:
   void getDependentDialects(DialectRegistry &registry) const override {
     registry.insert<func::FuncDialect, mk::MagicKernelDialect,
-                    tts::TritonStructuredDialect, triton::TritonDialect,
-                    arith::ArithDialect, memref::MemRefDialect,
-                    tensor::TensorDialect>();
+                    mlir::dsa::DsaDialect, tts::TritonStructuredDialect,
+                    triton::TritonDialect, arith::ArithDialect,
+                    memref::MemRefDialect, tensor::TensorDialect>();
   }
 
   void runOnOperation() override {

--- a/third_party/tsingmicro/lib/Conversion/Tx81ToLLVM/Tx81ToLLVM.cpp
+++ b/third_party/tsingmicro/lib/Conversion/Tx81ToLLVM/Tx81ToLLVM.cpp
@@ -94,6 +94,7 @@ const char reduceMaxFuncName[] = "__ReduceMax";
 const char reduceMinFuncName[] = "__ReduceMin";
 const char reduceMulFuncName[] = "__ReduceMul";
 const char cumsumPadFuncName[] = "__CumsumPad";
+const char randGenFuncName[] = "__RandGen";
 // Int8
 const char int8ToBf16FuncName[] = "__INT8_BF16";
 const char int8ToFp16FuncName[] = "__INT8_FP16";
@@ -1412,6 +1413,51 @@ struct CumsumOpConversion : public OpConversionPattern<tx::CumsumOp> {
     rewriter.create<LLVM::CallOp>(loc, TypeRange{}, cumsumPadFuncName,
                                   ValueRange{src, exclusive, total, scratch,
                                              rank, axis, shapeArray, pad, fmt});
+    rewriter.eraseOp(op);
+    return success();
+  }
+};
+
+struct RandGenOpConversion : public OpConversionPattern<tx::RandGenOp> {
+  using OpConversionPattern<tx::RandGenOp>::OpConversionPattern;
+
+  LogicalResult
+  matchAndRewrite(tx::RandGenOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Location loc = op.getLoc();
+    auto module = op->getParentOfType<ModuleOp>();
+    auto *ctx = rewriter.getContext();
+    auto voidTy = LLVM::LLVMVoidType::get(ctx);
+    auto i8PtrTy = LLVM::LLVMPointerType::get(ctx);
+    auto i32Ty = rewriter.getI32Type();
+    auto i16Ty = rewriter.getI16Type();
+
+    // void __RandGen(uint64_t *src0, uint64_t *src1, uint64_t *dst0,
+    //                uint64_t *dst1, uint64_t *dst2, uint32_t byte_count,
+    //                uint16_t fmt);
+    SmallVector<Type, 7> argTypes = {i8PtrTy, i8PtrTy, i8PtrTy, i8PtrTy,
+                                     i8PtrTy, i32Ty,   i16Ty};
+    (void)triton::declareTx81Function(module, rewriter, loc, randGenFuncName,
+                                      voidTy, argTypes);
+
+    Value src0 =
+        rewriter.create<LLVM::IntToPtrOp>(loc, i8PtrTy, adaptor.getSrc0());
+    Value src1 =
+        rewriter.create<LLVM::IntToPtrOp>(loc, i8PtrTy, adaptor.getSrc1());
+    Value dst0 =
+        rewriter.create<LLVM::IntToPtrOp>(loc, i8PtrTy, adaptor.getDst0());
+    Value dst1 =
+        rewriter.create<LLVM::IntToPtrOp>(loc, i8PtrTy, adaptor.getDst1());
+    Value dst2 =
+        rewriter.create<LLVM::IntToPtrOp>(loc, i8PtrTy, adaptor.getDst2());
+    Value byteCount = rewriter.create<LLVM::ConstantOp>(
+        loc, i32Ty, rewriter.getI32IntegerAttr(op.getByteCount()));
+    Value fmt = rewriter.create<LLVM::ConstantOp>(
+        loc, i16Ty, rewriter.getI16IntegerAttr(op.getFmt()));
+
+    rewriter.create<LLVM::CallOp>(
+        loc, TypeRange{}, randGenFuncName,
+        ValueRange{src0, src1, dst0, dst1, dst2, byteCount, fmt});
     rewriter.eraseOp(op);
     return success();
   }
@@ -2881,6 +2927,7 @@ public:
                  AtomicBarrierOpConversion<tx::AtomicBarrierInOp, atomicBarrierInFuncName>,
                  AtomicBarrierOpConversion<tx::AtomicBarrierOutOp, atomicBarrierOutFuncName>,
                  CumsumOpConversion,
+                 RandGenOpConversion,
                  MaskMoveOpConversion,
                  BitToFPOpConversion,
                  ChannelNormOpConversion,   // NOTE: No op used

--- a/third_party/tsingmicro/lib/Dialect/MagicKernel/IR/MagicKernelDialect.cpp
+++ b/third_party/tsingmicro/lib/Dialect/MagicKernel/IR/MagicKernelDialect.cpp
@@ -31,7 +31,8 @@ void MagicKernelDialect::initialize() {
       mk::AtomicCASOp, mk::ArgMaxOp, mk::ArgMinOp, mk::Bit2FpOp, mk::MaskMoveOp,
       mk::UnEqualVV, mk::EqualVV, mk::EqualVS, mk::LessThenVS, mk::BoolEqualVS,
       mk::ReduceMaxOp, mk::ReduceMinOp, mk::ReduceSumOp, mk::DequantOp,
-      mk::CumsumOp, mk::BitcastOp, mk::AddVS, mk::SubVS, mk::MulVS>();
+      mk::CumsumOp, mk::RandGenOp, mk::BitcastOp, mk::AddVS, mk::SubVS,
+      mk::MulVS>();
 }
 
 //===----------------------------------------------------------------------===//

--- a/third_party/tsingmicro/lib/Dialect/MagicKernel/Transforms/BufferizableOpInterfaceImpl.cpp
+++ b/third_party/tsingmicro/lib/Dialect/MagicKernel/Transforms/BufferizableOpInterfaceImpl.cpp
@@ -305,6 +305,7 @@ void mlir::mk::registerBufferizableOpInterfaceExternalModels(
         MKOpInterfaceHelper<mk::GeluOp>::registerOpInterface(ctx);
         MKOpInterfaceHelper<mk::GatherOp>::registerOpInterface(ctx);
         MKOpInterfaceHelper<mk::CumsumOp>::registerOpInterface(ctx);
+        MKOpInterfaceHelper<mk::RandGenOp>::registerOpInterface(ctx);
         MKOpInterfaceHelper<mk::PrintOp>::registerOpInterface(ctx);
         mk::AtomicRMWOp::attachInterface<AtomicRMWOpInterface>(*ctx);
         mk::AtomicCASOp::attachInterface<AtomicCASOpInterface>(*ctx);

--- a/third_party/tsingmicro/lib/Dialect/MagicKernel/Transforms/MaterializeStridedLinalgInputsPass.cpp
+++ b/third_party/tsingmicro/lib/Dialect/MagicKernel/Transforms/MaterializeStridedLinalgInputsPass.cpp
@@ -1,4 +1,5 @@
 
+#include "magic-kernel/Dialect/IR/MagicKernelDialect.h"
 #include "magic-kernel/Transforms/Passes.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
 #include "mlir/Dialect/Func/IR/FuncOps.h"
@@ -117,6 +118,101 @@ struct MaterializeStridedLinalgInputsPass
         rewriter.create<memref::CopyOp>(loc, subview, alloc);
 
         generic->setOperand(inputOperand->getOperandNumber(), alloc);
+      }
+    }
+
+    SmallVector<Operation *> vsOps;
+    func.walk([&](Operation *op) {
+      if (isa<mk::AddVS, mk::SubVS, mk::MulVS>(op))
+        vsOps.push_back(op);
+    });
+
+    for (Operation *op : vsOps) {
+      auto vsOp = dyn_cast<DestinationStyleOpInterface>(op);
+      if (!vsOp)
+        continue;
+
+      bool allInitsEqualInput = true;
+      Value input = vsOp.getDpsInputOperands().front()->get();
+      for (OpOperand &init : vsOp.getDpsInitsMutable()) {
+        if (init.get() != input) {
+          allInitsEqualInput = false;
+          break;
+        }
+      }
+
+      auto isStridedSubview = [](Value v, MemRefType *outType = nullptr) {
+        auto subview = v.getDefiningOp<memref::SubViewOp>();
+        if (!subview)
+          return false;
+        auto subviewType = dyn_cast<MemRefType>(subview.getType());
+        if (!subviewType || !hasNonContiguousStrides(subviewType))
+          return false;
+        if (outType)
+          *outType = subviewType;
+        return true;
+      };
+      auto createContiguousAlloc = [&](MemRefType type, Value operand,
+                                       Location loc) {
+        SmallVector<Value> dynamicSizes;
+        for (auto [idx, dim] : llvm::enumerate(type.getShape())) {
+          if (ShapedType::isDynamic(dim)) {
+            dynamicSizes.push_back(
+                rewriter.create<memref::DimOp>(loc, operand, idx));
+          }
+        }
+        auto allocType =
+            MemRefType::get(type.getShape(), type.getElementType(),
+                            MemRefLayoutAttrInterface{}, type.getMemorySpace());
+        return rewriter.create<memref::AllocOp>(loc, allocType, dynamicSizes);
+      };
+
+      if (allInitsEqualInput) {
+        MemRefType subviewType;
+        if (!isStridedSubview(input, &subviewType))
+          continue;
+
+        rewriter.setInsertionPoint(op);
+        Location loc = op->getLoc();
+
+        Value alloc = createContiguousAlloc(subviewType, input, loc);
+        rewriter.create<memref::CopyOp>(loc, input, alloc);
+
+        rewriter.modifyOpInPlace(op, [&]() {
+          op->setOperand(0, alloc);
+          for (OpOperand &init : vsOp.getDpsInitsMutable()) {
+            if (init.get() == input)
+              init.set(alloc);
+          }
+        });
+
+        rewriter.setInsertionPointAfter(op);
+        rewriter.create<memref::CopyOp>(loc, alloc, input);
+        continue;
+      }
+
+      rewriter.setInsertionPoint(op);
+      Location loc = op->getLoc();
+
+      MemRefType inputSubviewType;
+      if (isStridedSubview(input, &inputSubviewType)) {
+        Value alloc = createContiguousAlloc(inputSubviewType, input, loc);
+        rewriter.create<memref::CopyOp>(loc, input, alloc);
+        rewriter.modifyOpInPlace(op, [&]() { op->setOperand(0, alloc); });
+      }
+
+      for (OpOperand &init : vsOp.getDpsInitsMutable()) {
+        MemRefType initSubviewType;
+        if (!isStridedSubview(init.get(), &initSubviewType))
+          continue;
+
+        rewriter.setInsertionPoint(op);
+        Value alloc = createContiguousAlloc(initSubviewType, init.get(), loc);
+        rewriter.create<memref::CopyOp>(loc, init.get(), alloc);
+        rewriter.modifyOpInPlace(op, [&]() { init.set(alloc); });
+
+        rewriter.setInsertionPointAfter(op);
+        rewriter.create<memref::CopyOp>(loc, alloc, init.get());
       }
     }
   }


### PR DESCRIPTION

- tle-dsa: new elementwise binary ops (add/sub/mul/maximum/minimum/div), to_tensor/to_buffer tensor<->buffer bridging, dsa.randgen for tx81 peri, dsa.bitcast, and strided extract_slice/insert_slice ops
- tsingmicro backend: lower the new DSA ops (TLEToMK/MKToTx81/Tx81ToLLVM/ LinalgToMK, MaterializeStridedLinalgInputs), add randgen CRT support
- driver: preload kernel module once and launch via txLaunchKernel handle, with TXDA_LAUNCH_VIA_GGL fallback to txLaunchKernelGGL; skip redundant txSetDevice on the hot path; fix Py_DECREF/refcount and stray fflush