### PR TITLE
[BUILD] deb: strip DWARF from libtriton/libproton and skip dh_dwz

### DIFF
--- a/packaging/debian/python3-flagtree-nvidia.lintian-overrides
+++ b/packaging/debian/python3-flagtree-nvidia.lintian-overrides
@@ -1,0 +1,6 @@
+# libtriton/libproton keep their symbol tables on purpose: Triton's JIT does
+# runtime symbol lookups in them. Only the DWARF sections are removed
+# (strip --strip-debug in debian/rules); lintian counts a present .symtab as
+# "unstripped".
+unstripped-binary-or-object [usr/lib/python3/dist-packages/triton/_C/libtriton.cpython-312-x86_64-linux-gnu.so]
+unstripped-binary-or-object [usr/lib/python3/dist-packages/triton/_C/libproton.cpython-312-x86_64-linux-gnu.so]

--- a/packaging/debian/rules
+++ b/packaging/debian/rules
@@ -48,6 +48,18 @@ override_dh_shlibdeps:
 	dh_shlibdeps -- --ignore-missing-info
 
 override_dh_strip:
-	# Stripping the embedded LLVM-built .so files breaks Triton's runtime,
-	# which expects symbols for JIT codegen lookups.
+	# libtriton/libproton must keep their symbol tables (Triton's JIT does
+	# symbol lookups), so exclude them from dh_strip's --strip-unneeded and
+	# instead drop only the DWARF sections: --strip-debug keeps .symtab and
+	# .dynsym while removing .debug_* (verified: import triton, the compiler
+	# and the nvidia driver load fine afterwards). This takes libtriton from
+	# 724 MB to 187 MB; lintian still counts the kept .symtab as "unstripped",
+	# which the package's lintian-overrides file documents.
 	dh_strip --no-automatic-dbgsym -X libtriton -X libproton
+	find debian/$(PKG) \( -name 'libtriton.*.so' -o -name 'libproton.*.so' \) \
+		-exec strip --strip-debug {} +
+
+override_dh_dwz:
+	# dwz would place its multifile under usr/lib/debug/.dwz/ inside the
+	# runtime package (lintian: debug-suffix-not-dbg); with the debug info
+	# stripped above there is nothing useful for it to compress anyway.


### PR DESCRIPTION
## Why

The deb ships `libtriton` **724 MB — 537 MB of which is `.debug_*` sections** — and `libproton` completely unstripped, because `debian/rules` excludes them from `dh_strip` (Triton's JIT needs their symbol tables). `dh_dwz` also leaves its multifile under `usr/lib/debug/.dwz/` **inside the runtime package**. Both were found while re-auditing rpath/hardcoded paths for #798 (the absolute `/src/...`, `/root/.triton/llvm/...` strings in the binaries are exactly this DWARF data).

## What

- After `dh_strip`, run `strip --strip-debug` on the two excluded objects: it removes only the DWARF sections and **keeps `.symtab`/`.dynsym`**, which is what the JIT lookups use.
- No-op `override_dh_dwz` (nothing left for it to compress, and its output does not belong in the runtime package).
- `lintian-overrides` documenting the deliberately kept symbol tables (lintian counts a present `.symtab` as "unstripped").

## Verified

Built with the cached wheel (validated on top of #1066's branch; the change applies to `main` independently):

| | before | after |
|---|---|---|
| `libtriton…so` | 724 MB | **187 MB** |
| `.deb` | 240 MB | **80 MB** |
| lintian `debug-suffix-not-dbg` | 1 | 0 |

The in-image smoke (`apt-get install` + `import triton`) still passes, and a separately installed package imports `triton`, `triton.compiler` and the nvidia driver after `--strip-debug`.

No conflict with #1066 (different hunks of `debian/rules`); whichever merges second rebases trivially.

Refs #798.