### PR TITLE
[AMD/ROCm] Preserve volatile loads during AMD/ROCm LLVM lowering

### DIFF
--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -546,6 +546,7 @@ def MaskedLoadOp : TT_AMDGPU_Op<"masked_load", []> {
     LLVM_Type:$falseVal,
     Optional<I16>:$multicastMask,
     DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
+    // isVolatile attribute added in Triton 3.8: triton/pull/11223
     DefaultValuedAttr<BoolAttr, "false">:$isVolatile,
     DefaultValuedAttr<BoolAttr, "false">:$forceNoAlias
   );
@@ -559,6 +560,7 @@ def MaskedLoadOp : TT_AMDGPU_Op<"masked_load", []> {
     (`forceNoAlias` $forceNoAlias^)?
     attr-dict `:` functional-type(operands, results)
   }];
+  // 'volatile' assembly format added in Triton 3.8: triton/pull/11223
 }
 
 //===----------------------------------------------------------------------===//

--- a/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
+++ b/third_party/amd/include/Dialect/TritonAMDGPU/IR/TritonAMDGPUOps.td
@@ -546,6 +546,7 @@ def MaskedLoadOp : TT_AMDGPU_Op<"masked_load", []> {
     LLVM_Type:$falseVal,
     Optional<I16>:$multicastMask,
     DefaultValuedAttr<TT_CacheModifierAttr, "::mlir::triton::CacheModifier::NONE">:$cache,
+    DefaultValuedAttr<BoolAttr, "false">:$isVolatile,
     DefaultValuedAttr<BoolAttr, "false">:$forceNoAlias
   );
 
@@ -554,6 +555,7 @@ def MaskedLoadOp : TT_AMDGPU_Op<"masked_load", []> {
   let assemblyFormat = [{
     $ptr `,` $mask `,` $falseVal (`,` $multicastMask^)?
     oilist(`cacheModifier` `=` $cache)
+    (`volatile` $isVolatile^)?
     (`forceNoAlias` $forceNoAlias^)?
     attr-dict `:` functional-type(operands, results)
   }];

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -694,7 +694,7 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
             otherElems, vecStart);
 
       Value loadVal = llLoad(rewriter, loc, ptr, vecTy, pred, falseVal,
-                             multicastMask, cacheMod);
+                             multicastMask, cacheMod, op.getIsVolatile());
       for (size_t ii = 0; ii < vec; ++ii) {
         Value vecIdx = createIndexAttrConstant(
             rewriter, loc, getTypeConverter()->getIndexType(), ii);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/LoadStoreOpToLLVM.cpp
@@ -693,6 +693,7 @@ struct LoadOpConversion : public ConvertOpToLLVMPattern<triton::LoadOp>,
             rewriter, this->getTypeConverter(), loc, cast<VectorType>(vecTy),
             otherElems, vecStart);
 
+      // Triton 3.8: triton/pull/11223
       Value loadVal = llLoad(rewriter, loc, ptr, vecTy, pred, falseVal,
                              multicastMask, cacheMod, op.getIsVolatile());
       for (size_t ii = 0; ii < vec; ++ii) {

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MaskedOpsToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MaskedOpsToLLVM.cpp
@@ -39,6 +39,7 @@ public:
     std::tie(volatileFlag, nonTmpFlag) =
         mlir::LLVM::AMD::getCacheModifierFlagsForLoadStore(
             cacheMod, mlir::LLVM::AMD::MemoryOp::Load);
+    volatileFlag |= loadOp.getIsVolatile();
 
     auto createLoadWithAttrs = [&](Location loadLoc) -> Value {
       int vecBits = 0;
@@ -48,8 +49,11 @@ public:
         vecBits = elemTy.getIntOrFloatBitWidth();
       }
       assert(vecBits != 0);
-      // We can only multicast for 32, 64, 128 bit load size (hw limitation)
-      if (multicastMask && targetInfo.supportsClusterLoadBitWidth(vecBits)) {
+      bool supportsClusterLoad =
+          targetInfo.supportsClusterLoadBitWidth(vecBits);
+      // The cluster load intrinsic cannot represent LLVM volatile semantics,
+      // so use a regular load for volatile accesses.
+      if (multicastMask && supportsClusterLoad && !loadOp.getIsVolatile()) {
         std::string intrinsic =
             "llvm.amdgcn.cluster.load.b" + std::to_string(vecBits);
         auto cacheModBits = LLVM::AMD::getCtrlBitsForCacheModifierOnTarget(
@@ -63,7 +67,7 @@ public:
             rewriter, loc, intrinsic, {resTy},
             {ptr, b.i32_val(cacheModBits), multicastMask});
         return b.bitcast(clusterLoadOp->getResult(0), elemTy);
-      } else if (multicastMask) {
+      } else if (multicastMask && !supportsClusterLoad) {
         loadOp.emitRemark()
             << "Multicast with bit width " << vecBits << " is not supported on "
             << targetInfo.getArch() << " falling back to regular load";

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/MaskedOpsToLLVM.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/MaskedOpsToLLVM.cpp
@@ -39,6 +39,7 @@ public:
     std::tie(volatileFlag, nonTmpFlag) =
         mlir::LLVM::AMD::getCacheModifierFlagsForLoadStore(
             cacheMod, mlir::LLVM::AMD::MemoryOp::Load);
+    // Triton 3.8: triton/pull/11223
     volatileFlag |= loadOp.getIsVolatile();
 
     auto createLoadWithAttrs = [&](Location loadLoc) -> Value {
@@ -49,6 +50,7 @@ public:
         vecBits = elemTy.getIntOrFloatBitWidth();
       }
       assert(vecBits != 0);
+      // Triton 3.8: triton/pull/11223
       bool supportsClusterLoad =
           targetInfo.supportsClusterLoadBitWidth(vecBits);
       // The cluster load intrinsic cannot represent LLVM volatile semantics,
@@ -68,6 +70,7 @@ public:
             {ptr, b.i32_val(cacheModBits), multicastMask});
         return b.bitcast(clusterLoadOp->getResult(0), elemTy);
       } else if (multicastMask && !supportsClusterLoad) {
+        // Triton 3.8: triton/pull/11223
         loadOp.emitRemark()
             << "Multicast with bit width " << vecBits << " is not supported on "
             << targetInfo.getArch() << " falling back to regular load";

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -164,7 +164,8 @@ Value TargetInfo::loadDShared(RewriterBase &rewriter, Location loc, Value ptr,
   bool addAliasGroup = localLoadOp && requiresAliasInfoForAsyncOps() &&
                        isSyncedViaAsyncWait(localLoadOp);
   return mlir::LLVM::AMD::llLoad(rewriter, loc, ptr, elemTy, pred, falseVal, {},
-                                 triton::CacheModifier::NONE, addAliasGroup);
+                                 triton::CacheModifier::NONE,
+                                 /*isVolatile=*/false, addAliasGroup);
 }
 
 Value TargetInfo::shuffleXor(RewriterBase &rewriter, Location loc, Value val,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/TargetInfo.cpp
@@ -163,6 +163,7 @@ Value TargetInfo::loadDShared(RewriterBase &rewriter, Location loc, Value ptr,
                                             rewriter.getZeroAttr(elemTy));
   bool addAliasGroup = localLoadOp && requiresAliasInfoForAsyncOps() &&
                        isSyncedViaAsyncWait(localLoadOp);
+  // Triton 3.8: triton/pull/11223
   return mlir::LLVM::AMD::llLoad(rewriter, loc, ptr, elemTy, pred, falseVal, {},
                                  triton::CacheModifier::NONE,
                                  /*isVolatile=*/false, addAliasGroup);

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -393,6 +393,7 @@ Value emitCtaMulticastMask(RewriterBase &rewriter, Location loc, Value groupId,
   return ctaMask;
 }
 
+// Triton 3.8: triton/pull/11223
 Value llLoad(RewriterBase &rewriter, Location loc, Value ptr, Type elemTy,
              Value pred, Value falseVal, Value multicastMask,
              triton::CacheModifier cm, bool isVolatile,

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -397,9 +397,9 @@ Value llLoad(RewriterBase &rewriter, Location loc, Value ptr, Type elemTy,
              Value pred, Value falseVal, Value multicastMask,
              triton::CacheModifier cm, bool isVolatile,
              bool forceNoAliasAsyncLoads) {
-  return triton::amdgpu::MaskedLoadOp::create(rewriter, loc, elemTy, ptr, pred,
-                                              falseVal, multicastMask, cm,
-                                              isVolatile, forceNoAliasAsyncLoads)
+  return triton::amdgpu::MaskedLoadOp::create(
+             rewriter, loc, elemTy, ptr, pred, falseVal, multicastMask, cm,
+             isVolatile, forceNoAliasAsyncLoads)
       .getResult();
 }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.cpp
@@ -395,10 +395,11 @@ Value emitCtaMulticastMask(RewriterBase &rewriter, Location loc, Value groupId,
 
 Value llLoad(RewriterBase &rewriter, Location loc, Value ptr, Type elemTy,
              Value pred, Value falseVal, Value multicastMask,
-             triton::CacheModifier cm, bool forceNoAliasAsyncLoads) {
+             triton::CacheModifier cm, bool isVolatile,
+             bool forceNoAliasAsyncLoads) {
   return triton::amdgpu::MaskedLoadOp::create(rewriter, loc, elemTy, ptr, pred,
                                               falseVal, multicastMask, cm,
-                                              forceNoAliasAsyncLoads)
+                                              isVolatile, forceNoAliasAsyncLoads)
       .getResult();
 }
 

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -50,7 +50,7 @@ getCacheModifierFlagsForLoadStore(const triton::CacheModifier &cm, MemoryOp op);
 Value llLoad(RewriterBase &rewriter, Location loc, Value ptr, Type elemTy,
              Value pred, Value falseVal, Value multicastMask,
              triton::CacheModifier cm = triton::CacheModifier::NONE,
-             bool forceNoAliasAsyncLoads = false);
+             bool isVolatile = false, bool forceNoAliasAsyncLoads = false);
 
 // Stores to shared or global memory with predication.
 // forceNoAliasAsyncLoads=true adds alias information to the llvm.store to

--- a/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
+++ b/third_party/amd/lib/TritonAMDGPUToLLVM/Utility.h
@@ -50,6 +50,7 @@ getCacheModifierFlagsForLoadStore(const triton::CacheModifier &cm, MemoryOp op);
 Value llLoad(RewriterBase &rewriter, Location loc, Value ptr, Type elemTy,
              Value pred, Value falseVal, Value multicastMask,
              triton::CacheModifier cm = triton::CacheModifier::NONE,
+             // Triton 3.8: triton/pull/11223
              bool isVolatile = false, bool forceNoAliasAsyncLoads = false);
 
 // Stores to shared or global memory with predication.


### PR DESCRIPTION
## Summary
Port of [triton-lang/triton#11223](https://github.com/triton-lang/triton/pull/11223) to the FlagTree AMD backend.
Preserve `tl.load(..., volatile=True)` through AMD LLVM lowering. Previously the volatility flag was dropped during lowering, which allowed the optimizer to hoist polling-loop loads out of their loop. The loop then spun on a stale value forever, causing HIP kernels to hang on AMD GPUs.

## Motivation
The bug reproduces as a GPU hang in the FlagGems `mode` operator test on R9700 (gfx1201). A polling loop inside the kernel reads a flag with a volatile load; once volatility is lost, the load is hoisted and the loop never terminates.

## What changed
The `isVolatile` flag is now threaded through the AMD lowering path all the way to the final LLVM load:
  - `TritonAMDGPUOps.td` — add an `isVolatile` attribute (default `false`) to
    `MaskedLoadOp`, plus its assembly format.
  - `Utility.h` / `Utility.cpp` — add an `isVolatile` parameter to `llLoad` and
  forward
    it to `MaskedLoadOp::create`.
  - `LoadStoreOpToLLVM.cpp` — pass `op.getIsVolatile()` when converting
  `triton::LoadOp`.
  - `MaskedOpsToLLVM.cpp` — OR the op's `isVolatile` into the emitted LLVM load's
    volatile flag, and fall back to a regular load for volatile accesses that would
    otherwise use the cluster-load intrinsic (which cannot represent LLVM volatile
    semantics).
  - `TargetInfo.cpp` — pass `isVolatile=false` for `loadDShared` (adapts to the new
    signature; shared-memory loads are unaffected).

## Test plan
Verified on R9700 (gfx1201, ROCm 7.2.x) with FlagGems `mode` operator tests:

  - **Before this change:** `pytest -m mode test_mode.py -k "dtype1-0-True-shape1"`
    hangs (frozen 90s+, one GPU pegged at 100%). Exact hanging call:
    `mode(float32 input, shape=(4096, 256), dim=0, keepdim=True)`.
  - **After this change:** the same case passes in ~2.9s; full `mode` sweep is
    **76 passed in ~40s** with no hang.


