### PR TITLE
[BACKEND][PPU] Low-precision float support: fp8e4nv software cast, resolve_dot capability rules, Fp4ToFp capability gating

### DIFF
--- a/python/triton/backends/__init__.py
+++ b/python/triton/backends/__init__.py
@@ -158,6 +158,9 @@ class _LanguageExtensions:
     def __getattr__(self, name):
         if name in self._symbols:
             return self._symbols[name]
+        # dunder probes (inspect, copy, is_builtin, ...) must get AttributeError
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
         providers = [(backend_name, getattr(module, name))
                      for backend_name, module in self._get_modules()
                      if hasattr(module, name)]

--- a/python/triton/backends/compiler.py
+++ b/python/triton/backends/compiler.py
@@ -23,7 +23,7 @@
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 from types import ModuleType
 
 
@@ -34,6 +34,31 @@ class GPUTarget(object):
     # Target architecture, e.g., 90 (for cuda compute capability), gfx940 (for hip)
     arch: Union[int, str]
     warp_size: int
+
+
+class DotSupport(Enum):
+    """How a backend supports a dot dtype/format combination."""
+    NATIVE = "native"
+    EMULATED = "emulated"
+    UNSUPPORTED = "unsupported"
+
+
+@dataclass(frozen=True)
+class DotCap:
+    """Answer to a backend `resolve_dot(a_dtype, b_dtype, acc_dtype, M, N, K)` /
+    `resolve_dot_scaled(lhs_format, rhs_format)` codegen-function query: the
+    semantic layer rejects UNSUPPORTED combinations with `diag` as the error
+    message and emits `diag` as a compile-time warning for EMULATED ones."""
+    support: DotSupport
+    diag: Optional[str] = None
+
+    @property
+    def supported(self) -> bool:
+        return self.support is not DotSupport.UNSUPPORTED
+
+    @property
+    def native(self) -> bool:
+        return self.support is DotSupport.NATIVE
 
 
 class Language(Enum):

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -836,10 +836,21 @@ class TritonSemantic(Generic[TensorTy]):
                                  "Source scalar type is " + str(src_sca_ty) + " and destination type is " +
                                  str(dst_sca_ty))
 
-        if (src_sca_ty.is_fp8e4b15() or dst_sca_ty.is_fp8e4b15()):
-            assert self.builder.codegen_fns.get(
-                "convert_custom_types") is not None, "target doesn't provide conversion for this type."
-            return self.builder.codegen_fns["convert_custom_types"](input, dst_ty, fp_downcast_rounding, _semantic=self)
+        if src_sca_ty.is_fp8() or dst_sca_ty.is_fp8():
+            options = self.builder.options
+            cast_whitelist = getattr(options, "supported_fp8_cast_dtypes", None)
+            if cast_whitelist is not None and src_sca_ty.is_floating() and dst_sca_ty.is_floating():
+                for ty in (src_sca_ty, dst_sca_ty):
+                    if ty.is_fp8() and ty.name not in cast_whitelist:
+                        raise ValueError(f"cast involving type {ty} is not supported in this architecture. "
+                                         f"The supported fp8 cast dtypes are {cast_whitelist}")
+            # Backends declare fp8 dtypes with software casts under "custom_cast_fp8_dtypes";
+            # the default preserves the legacy fp8e4b15-only routing.
+            custom_cast_dtypes = getattr(options, "custom_cast_fp8_dtypes", ("fp8e4b15", ))
+            if src_sca_ty.name in custom_cast_dtypes or dst_sca_ty.name in custom_cast_dtypes:
+                custom_cast = self.builder.codegen_fns.get("convert_custom_types")
+                assert custom_cast is not None, "target doesn't provide conversion for this type."
+                return custom_cast(input, dst_ty, fp_downcast_rounding, _semantic=self)
         # Casting with customized floating types involved: fp8 <=> bf16, fp16, fp32, fp64
         # and non-default rounding modes for downcasting
         if (src_sca_ty.is_fp8() and dst_sca_ty.is_floating()) or \
@@ -1508,10 +1519,12 @@ class TritonSemantic(Generic[TensorTy]):
             max_num_imprecise_acc: int, out_dtype: tl.dtype) -> TensorTy:
         assert lhs.type.is_block() and rhs.type.is_block()
 
+        # resolve_dot backends own the dtype rules (queried once shapes are known)
+        resolve_dot = self.builder.codegen_fns.get("resolve_dot")
         if lhs.dtype.is_fp8() and rhs.dtype.is_fp8():
             # All combinations of supported fp8 x fp8 are permitted
             pass
-        else:
+        elif resolve_dot is None:
             assert lhs.dtype in (tl.int8, tl.uint8, tl.float16, tl.bfloat16, tl.float32,
                                  tl.float64), f"Unsupported lhs dtype {lhs.dtype}"
             assert rhs.dtype in (tl.int8, tl.uint8, tl.float16, tl.bfloat16, tl.float32,
@@ -1551,6 +1564,15 @@ class TritonSemantic(Generic[TensorTy]):
             -2].value, f"First input shape ({lhs.shape}) and second input shape {rhs.shape} are not compatible for matmul (second index of first shape ({lhs.shape[-1].value}) must be equal to first index of second shape ({rhs.shape[-2].value})"
         assert self.builder.codegen_fns.get(
             "min_dot_size") is not None, "target doesn't provide lower shape bounds for dot."
+        if resolve_dot is not None:
+            # queried after the legacy e4b15/fnuz upcasts above so rules see the effective dtypes
+            dot_cap = resolve_dot(lhs.dtype.name, rhs.dtype.name, out_dtype.name, lhs.shape[-2].value,
+                                  rhs.shape[-1].value, lhs.shape[-1].value)
+            if not dot_cap.supported:
+                raise ValueError(dot_cap.diag or f"tl.dot: {lhs.dtype} x {rhs.dtype} is not supported on this product")
+            if not dot_cap.native:
+                warnings.warn(dot_cap.diag or f"tl.dot: {lhs.dtype} x {rhs.dtype} is not native on this "
+                              "product: emulated path (native=false)")
         min_dot_size = self.builder.codegen_fns["min_dot_size"](lhs.type, rhs.type)
         assert lhs.shape[-2].value >= min_dot_size[0] and lhs.shape[-1].value >= min_dot_size[2] \
             and rhs.shape[-1].value >= min_dot_size[1], \
@@ -1650,6 +1672,16 @@ class TritonSemantic(Generic[TensorTy]):
         allowed_formats = {"e2m1", "e4m3", "e5m2", "bf16", "fp16"}
         assert lhs_format in allowed_formats, f"NYI: lhs_format {lhs_format}"
         assert rhs_format in allowed_formats, f"NYI: rhs_format {rhs_format}"
+        # non-native (decomposed) format combinations warn at compile time
+        resolve_dot_scaled = self.builder.codegen_fns.get("resolve_dot_scaled")
+        if resolve_dot_scaled is not None:
+            scaled_cap = resolve_dot_scaled(lhs_format, rhs_format)
+            if not scaled_cap.supported:
+                raise ValueError(scaled_cap.diag
+                                 or f"tl.dot_scaled: {lhs_format} x {rhs_format} is not supported on this product")
+            if not scaled_cap.native:
+                warnings.warn(scaled_cap.diag or f"tl.dot_scaled: {lhs_format} x {rhs_format} is not native "
+                              "on this product: decomposed to an emulated path (native=false)")
         rhs_scale_is_none = rhs_scale is None or (isinstance(rhs_scale, tl.constexpr) and rhs_scale.value is None)
         lhs_scale_is_none = lhs_scale is None or (isinstance(lhs_scale, tl.constexpr) and lhs_scale.value is None)
         lhs = self._bitcast_to_fp_type(lhs, lhs_format)

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -221,67 +221,123 @@ def _get_np_dtype(tt_dtype):
     return np_types[tt_dtype]
 
 
+def _float_special_kind(dtype):
+    """Special-value convention of a float format:
+    "ieee": inf at e=max/m=0, nan at e=max/m!=0 (fp16/bf16/fp32/fp64/fp8e5)
+    "fn":   no inf; nan is all-ones exponent + all-ones mantissa (fp8e4nv)
+    "fnuz": no inf; nan is the sign bit only (fp8e4b8 / fp8e5b16)
+    "none": neither inf nor nan (fp8e4b15)
+    """
+    return {
+        tl.float8e4nv: "fn",
+        tl.float8e4b8: "fnuz",
+        tl.float8e5b16: "fnuz",
+        tl.float8e4b15: "none",
+    }.get(dtype, "ieee")
+
+
+def _decode_float_to_fp64(bits, dtype):
+    """Decode raw bit patterns of `dtype` into exact float64 values."""
+    if dtype == tl.float64:
+        return bits.view(np.float64).copy()
+    if dtype == tl.float32:
+        return bits.view(np.float32).astype(np.float64)
+    if dtype == tl.float16:
+        return bits.view(np.float16).astype(np.float64)
+    if dtype == tl.bfloat16:
+        return (bits.astype(np.uint32) << 16).view(np.float32).astype(np.float64)
+    mw = dtype.fp_mantissa_width
+    ew = dtype.primitive_bitwidth - mw - 1
+    bias = dtype.exponent_bias
+    kind = _float_special_kind(dtype)
+    b = bits.astype(np.int64)
+    sign = np.where((b >> (mw + ew)) & 1, -1.0, 1.0)
+    e = (b >> mw) & ((1 << ew) - 1)
+    m = b & ((1 << mw) - 1)
+    normal = np.ldexp(1.0 + m / (1 << mw), (e - bias).astype(np.int32))
+    subnormal = np.ldexp(m / (1 << mw), np.int32(1 - bias))
+    val = sign * np.where(e == 0, subnormal, normal)
+    e_max = (1 << ew) - 1
+    if kind == "ieee":
+        val = np.where((e == e_max) & (m == 0), sign * np.inf, val)
+        val = np.where((e == e_max) & (m != 0), np.nan, val)
+    elif kind == "fn":
+        val = np.where((e == e_max) & (m == (1 << mw) - 1), np.nan, val)
+    elif kind == "fnuz":
+        val = np.where(b == (1 << (mw + ew)), np.nan, val)
+    return val
+
+
+def _encode_fp64_to_float(val, dtype, rounding_mode):
+    """Encode float64 values into raw bit patterns of `dtype` with strict
+    RTNE/RTZ rounding; formats without inf saturate to max finite."""
+    mw = dtype.fp_mantissa_width
+    ew = dtype.primitive_bitwidth - mw - 1
+    bias = dtype.exponent_bias
+    kind = _float_special_kind(dtype)
+    e_max = (1 << ew) - 1
+    val = np.ascontiguousarray(val, dtype=np.float64)
+    b64 = val.view(np.uint64).astype(np.int64)
+    sign = (b64 >> 63) & 1
+    e_in = (b64 >> 52) & 0x7FF
+    m_in = b64 & ((1 << 52) - 1)
+    is_nan = np.isnan(val)
+    is_inf = np.isinf(val)
+    # significand with implicit bit; float64 subnormals have no implicit bit
+    denorm_in = e_in == 0
+    sig = np.where(denorm_in, m_in, m_in | (1 << 52))
+    unbiased = np.where(denorm_in, -1022, e_in - 1023)
+    # E <= 0 lands in the target's subnormal range and needs extra right-shifts
+    E = unbiased + bias
+    k = np.clip((52 - mw) + np.maximum(0, 1 - E), 0, 62)
+    keep = sig >> k
+    rem = sig & ((np.int64(1) << k) - 1)
+    if rounding_mode is None or rounding_mode == _ir.ROUNDING_MODE.RTNE:
+        half = np.where(k > 0, np.int64(1) << np.maximum(k - 1, 0), np.int64(0))
+        round_up = ((rem > half) | ((rem == half) & ((keep & 1) == 1))) & (k > 0)
+        keep = keep + round_up
+    elif rounding_mode == _ir.ROUNDING_MODE.RTZ:
+        pass
+    else:
+        raise ValueError(f"unsupported rounding mode {rounding_mode}")
+    # (E << mw) + keep - 2^mw lets a mantissa carry overflow into the exponent;
+    # in the subnormal case keep == 2^mw naturally becomes the minimum normal
+    expmant = np.where(E >= 1, (E << mw) + keep - (1 << mw), keep)
+    if kind == "ieee":
+        inf_code = e_max << mw
+        max_finite = inf_code - 1
+        if rounding_mode == _ir.ROUNDING_MODE.RTZ:
+            expmant = np.minimum(expmant, max_finite)  # RTZ never rounds to inf
+        else:
+            expmant = np.where(expmant >= inf_code, inf_code, expmant)
+        result = (sign << (mw + ew)) | expmant
+        result = np.where(is_inf, (sign << (mw + ew)) | inf_code, result)
+        result = np.where(is_nan, (sign << (mw + ew)) | inf_code | (1 << (mw - 1)), result)
+    elif kind == "fn":
+        max_finite = (e_max << mw) | ((1 << mw) - 2)
+        expmant = np.minimum(expmant, max_finite)  # satfinite (also maps inf)
+        result = (sign << (mw + ew)) | expmant
+        result = np.where(is_nan, (e_max << mw) | ((1 << mw) - 1), result)
+    elif kind == "fnuz":
+        max_finite = (e_max << mw) | ((1 << mw) - 1)
+        expmant = np.minimum(expmant, max_finite)
+        # fnuz has no -0 (the sign-only pattern is the NaN code): anything
+        # that rounds to zero encodes as +0
+        result = np.where(expmant == 0, np.int64(0), (sign << (mw + ew)) | expmant)
+        result = np.where(is_nan, np.int64(1) << (mw + ew), result)
+    else:  # "none" (fp8e4b15): no inf/nan representation, saturate
+        max_finite = (e_max << mw) | ((1 << mw) - 1)
+        expmant = np.minimum(expmant, max_finite)
+        result = (sign << (mw + ew)) | expmant
+    out_uint_dtype = getattr(np, f"uint{dtype.primitive_bitwidth}")
+    return result.astype(out_uint_dtype)
+
+
 def _convert_float(input, input_dtype, output_dtype, rounding_mode):
     input_uint_dtype = getattr(np, f"uint{input_dtype.primitive_bitwidth}")
-    output_unint_dtype = getattr(np, f"uint{output_dtype.primitive_bitwidth}")
-    input_bin = np.frombuffer(input.tobytes(), dtype=input_uint_dtype)
-    sign = (input_bin >> (input_dtype.primitive_bitwidth - 1)) & 0x01
-    input_exponent_width = input_dtype.primitive_bitwidth - input_dtype.fp_mantissa_width - 1
-    output_exponent_width = output_dtype.primitive_bitwidth - output_dtype.fp_mantissa_width - 1
-    significand = input_bin & ((1 << input_dtype.fp_mantissa_width) - 1)
-    bias_input = input_dtype.exponent_bias
-    bias_output = output_dtype.exponent_bias
-    exponent = ((input_bin >> input_dtype.fp_mantissa_width) & ((1 << input_exponent_width) - 1)).astype(np.int32)
-    subnormal_index = exponent == 0
-    if np.any(subnormal_index):
-        # Credit to Phil: phil@openai.com
-        # subnormal repr: ((-1.0)**sign) * (2.0**(1 - exp_bias)) * (2^(m0) + 2^(m1) + ... + 2^(mn))
-        # where m0, m1, ..., mn are the 1-bit of the mantissa
-        # convert it to normal repr: ((-1.0)**sign) * (2.0**(1 + m0 - exp_bias)) * (1 + 2^(m1 - m0) + ... + 2^(mn - m0))
-        bit_pos = np.zeros_like(input_bin, dtype=np.int32)
-        # Find the most significant bit of the mantissa in the significand
-        for i in range(input_dtype.fp_mantissa_width):
-            bit_index = ((significand >> i) & 0x01)
-            # pos should be >= 1
-            bit_pos[bit_index == 1] = input_dtype.fp_mantissa_width - i
-        zero_significand_index = significand == 0
-        exponent[subnormal_index] = 1 - bit_pos[subnormal_index]
-        # 0 significand and subnormal should be treated as 0
-        exponent[zero_significand_index & subnormal_index] = bias_input - bias_output
-        significand[subnormal_index] = (significand[subnormal_index] << bit_pos[subnormal_index]) & (
-            (1 << input_dtype.fp_mantissa_width) - 1)
-    # Prevent overflow and underflow
-    exponent_output = np.maximum(0, np.minimum((exponent - bias_input + bias_output), (1 << output_exponent_width) - 1))
-    exponent_output = exponent_output.astype(output_unint_dtype)
-    sign_output = sign.astype(output_unint_dtype)
-    if input_dtype.primitive_bitwidth > output_dtype.primitive_bitwidth:  # Downcast
-        significand_output = (significand >> (input_dtype.fp_mantissa_width - output_dtype.fp_mantissa_width)) & (
-            (1 << output_dtype.fp_mantissa_width) - 1)
-        if rounding_mode == _ir.ROUNDING_MODE.RTNE:  # Round to nearst even
-            # find the cut-off bit
-            cut_off = significand & (1 << (input_dtype.fp_mantissa_width - output_dtype.fp_mantissa_width - 1))
-            significand_output = significand_output + (cut_off > 0)
-        significand_output = significand_output.astype(output_unint_dtype)
-    else:  # Upcast
-        significand_output = (significand.astype(output_unint_dtype) <<
-                              (output_dtype.fp_mantissa_width - input_dtype.fp_mantissa_width)) & (
-                                  (1 << output_dtype.fp_mantissa_width) - 1)
-    subnormal_index = exponent_output == 0
-    if np.any(subnormal_index):  # underflow
-        # normal repr: ((-1.0)**sign) * (2.0**(exp - exp_bias_input)) * (1 + 2^(m0) + 2^(m1) + ... + 2^(mn))
-        # where m0, m1, ..., mn are the 1-bit of the mantissa
-        # shift = (1 - exp_bias_output) - (exp - exp_bias_input)
-        # convert it to subnormal repr: ((-1.0)**sign) * (2.0**(1 - exp_bias_output)) * (2^(-shift) + 2^(m0 - shift) + 2^(m1 - shift) + ... + 2^(mn - shift))
-        exponent = ((input_bin >> input_dtype.fp_mantissa_width) & ((1 << input_exponent_width) - 1)).astype(np.int32)
-        non_zero_exponent_index = exponent != 0
-        # If the original exponent is not zero, we still need to shift the significand and consider the 1.0 part in mantissa
-        subnormal_index = subnormal_index & non_zero_exponent_index
-        shift = np.zeros_like(input_bin, dtype=np.int32)
-        shift[subnormal_index] = (1 - bias_output) - (exponent[subnormal_index] - bias_input)
-        significand_output[subnormal_index] = (significand_output[subnormal_index] >> shift[subnormal_index]) | (
-            1 << (output_dtype.fp_mantissa_width - shift[subnormal_index]))
-    output = (sign_output << (output_dtype.primitive_bitwidth - 1)) | (
-        exponent_output << output_dtype.fp_mantissa_width) | significand_output
+    input_bits = np.frombuffer(input.tobytes(), dtype=input_uint_dtype)
+    val = _decode_float_to_fp64(input_bits, input_dtype)
+    output = _encode_fp64_to_float(val, output_dtype, rounding_mode)
     return output.reshape(input.shape)
 
 
@@ -459,7 +515,7 @@ class InterpreterBuilder:
         return TensorHandle(np.array([self.grid_dim[axis]], dtype=np.int32), tl.int32)
 
     # memory ops
-    def create_load(self, ptr, _0, _1, is_volatile):
+    def create_load(self, ptr, _0, _1, is_volatile, flagtree_hints=None):
         mask = TensorHandle(np.ones_like(ptr.data, dtype=bool), tl.int1)
         other = None
         return self.create_masked_load(ptr, mask, other, _0, _1, is_volatile)
@@ -468,7 +524,7 @@ class InterpreterBuilder:
         mask = TensorHandle(np.ones_like(ptr.data, dtype=bool), tl.int1)
         return self.create_masked_store(ptr, val, mask, None, None)
 
-    def create_masked_load(self, ptrs, mask, other, cache_modifier, eviction_policy, is_volatile):
+    def create_masked_load(self, ptrs, mask, other, cache_modifier, eviction_policy, is_volatile, flagtree_hints=None):
         dtype_tt = ptrs.get_element_ty()
         dtype_np = _get_np_dtype(dtype_tt)
         if other is None:

--- a/python/tutorials/precision/01-fp8.py
+++ b/python/tutorials/precision/01-fp8.py
@@ -1,0 +1,163 @@
+"""
+FP8 (E4M3FN)
+============
+
+In this tutorial, you will use the FP8 support of FlagTree.
+
+In doing so, you will learn about:
+
+* Querying per-product capability declarations and branching on them.
+
+* Casting to and from FP8 with satfinite saturation and strict RTNE/RTZ rounding,
+  which works even on products without native FP8 cvt instructions (software cast).
+
+* FP8 matmul: native where declared, otherwise a preserved emulation path that
+  warns at compile time and is declared native=false.
+
+"""
+
+# %%
+# Capability Declarations
+# -----------------------
+# FP8 support differs per product, so backends declare what they actually
+# provide: `supported_fp8_dtypes` for storage (dual-whitelist backends refine
+# it with `supported_fp8_storage_dtypes`), `supported_fp8_cast_dtypes`
+# for numerical casts (`custom_cast_fp8_dtypes` marks the ones lowered in
+# software), and `async_copy_dtypes` / `descriptor_dtypes` for data movement.
+# The declarations ship with every compiled kernel (`h.metadata`), so programs
+# can branch on them instead of guessing.
+
+import warnings
+
+import torch
+
+import triton
+import triton.language as tl
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+TARGET = triton.runtime.driver.active.get_current_target()
+
+
+def backend_options():
+    from triton.compiler import make_backend
+    return make_backend(TARGET).parse_options({})
+
+
+opts = backend_options()
+FP8_STORAGE = getattr(opts, "supported_fp8_storage_dtypes", getattr(opts, "supported_fp8_dtypes", ()))
+FP8_CAST = getattr(opts, "supported_fp8_cast_dtypes", FP8_STORAGE)
+FP8_SW_CAST = getattr(opts, "custom_cast_fp8_dtypes", ())
+
+print(f"target:            {TARGET.backend} / {TARGET.arch}")
+print(f"fp8 storage:       {FP8_STORAGE}")
+print(f"fp8 cast:          {FP8_CAST}")
+print(f"fp8 software cast: {FP8_SW_CAST}")
+
+HAS_E4M3FN = "fp8e4nv" in FP8_CAST
+
+# %%
+# FP8 Quantization Is Just a Cast
+# -------------------------------
+# E4M3FN downcasts saturate to +-448 (satfinite) and round with RTNE by default
+# (RTZ is also available via `fp_downcast_rounding`). NaN maps to the NaN code.
+# FP8 values travel as plain bytes: bitcast to uint8 for storage, bitcast back
+# to reinterpret. There is no implicit FP8 <-> integer numerical conversion.
+
+
+@triton.jit
+def fp8_quant_kernel(x_ptr, q_ptr, scale, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    x = tl.load(x_ptr + offs, mask=mask)
+    q = (x / scale).to(tl.float8e4nv)  # satfinite + RTNE built in
+    tl.store(q_ptr + offs, q.to(tl.uint8, bitcast=True), mask=mask)
+
+
+@triton.jit
+def fp8_dequant_kernel(q_ptr, y_ptr, scale, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    bits = tl.load(q_ptr + offs, mask=mask)
+    y = bits.to(tl.float8e4nv, bitcast=True).to(tl.float32) * scale
+    tl.store(y_ptr + offs, y, mask=mask)
+
+
+def demo_fp8_quantization():
+    n, block, scale = 4096, 1024, 0.05
+    x = torch.randn(n, device=DEVICE) * 10
+    q = torch.empty(n, dtype=torch.uint8, device=DEVICE)
+    y = torch.empty(n, dtype=torch.float32, device=DEVICE)
+    grid = (triton.cdiv(n, block), )
+    fp8_quant_kernel[grid](x, q, scale, n, BLOCK=block)
+    fp8_dequant_kernel[grid](q, y, scale, n, BLOCK=block)
+    # torch's CPU float8 conversion is the reference for in-range values; on
+    # overflow the two differ by design: torch yields NaN, Triton saturates
+    xs = x.cpu() / scale
+    ref_bits = xs.to(torch.float8_e4m3fn).view(torch.uint8)
+    in_range = xs.abs() <= 448.0
+    assert torch.equal(q.cpu()[in_range], ref_bits[in_range])
+    err = (y - x)[in_range.to(DEVICE)].abs().max().item()
+    print(f"fp8 quant/dequant: bit-exact vs torch reference in range, max roundtrip err {err:.4f}")
+
+    # satfinite: overflow clamps to +-448 instead of mapping to the NaN code
+    big = torch.tensor([1e6, -1e6], device=DEVICE)
+    qb = torch.empty(2, dtype=torch.uint8, device=DEVICE)
+    yb = torch.empty(2, dtype=torch.float32, device=DEVICE)
+    fp8_quant_kernel[(1, )](big, qb, 1.0, 2, BLOCK=2)
+    fp8_dequant_kernel[(1, )](qb, yb, 1.0, 2, BLOCK=2)
+    print(f"satfinite: 1e6 -> {yb[0].item()}, -1e6 -> {yb[1].item()}")
+
+
+if HAS_E4M3FN:
+    demo_fp8_quantization()
+else:
+    print("E4M3FN cast is not declared on this product -- skipping (as declared)")
+
+# %%
+# FP8 Matmul and the Emulation Warning
+# ------------------------------------
+# `tl.dot` legality is resolved by the backend's capability rules. Products with
+# native FP8 matrix cores run it natively; products that keep the legacy
+# FP16-promotion path still execute it, but emit a compile-time warning and
+# declare native=false, so silent degradation cannot happen. The warning shows
+# up when the kernel is actually compiled (a warm cache skips compilation).
+
+
+@triton.jit
+def fp8_matmul_kernel(a_ptr, b_ptr, c_ptr, M, N, K, BM: tl.constexpr, BN: tl.constexpr, BK: tl.constexpr):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BM + tl.arange(0, BM)
+    offs_n = pid_n * BN + tl.arange(0, BN)
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for k0 in range(0, K, BK):
+        offs_k = k0 + tl.arange(0, BK)
+        a = tl.load(a_ptr + offs_m[:, None] * K + offs_k[None, :])  # fp8 typed pointer
+        b = tl.load(b_ptr + offs_k[:, None] * N + offs_n[None, :])
+        acc = tl.dot(a, b, acc=acc)
+    tl.store(c_ptr + offs_m[:, None] * N + offs_n[None, :], acc)
+
+
+def demo_fp8_matmul():
+    M = N = K = 256
+    bm, bn, bk = 64, 64, 64
+    a8 = (torch.randn(M, K) * 0.5).to(torch.float8_e4m3fn).view(torch.uint8).to(DEVICE)
+    b8 = (torch.randn(K, N) * 0.5).to(torch.float8_e4m3fn).view(torch.uint8).to(DEVICE)
+    c = torch.empty((M, N), dtype=torch.float32, device=DEVICE)
+    grid = (M // bm, N // bn)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fp8_matmul_kernel[grid](triton.reinterpret(a8, tl.float8e4nv), triton.reinterpret(b8, tl.float8e4nv), c, M, N,
+                                K, BM=bm, BN=bn, BK=bk)
+    for msg in dict.fromkeys(str(w.message) for w in caught):
+        print(f"compile-time warning: {msg}")
+    a_ref = a8.cpu().view(torch.float8_e4m3fn).to(torch.float32)
+    b_ref = b8.cpu().view(torch.float8_e4m3fn).to(torch.float32)
+    torch.testing.assert_close(c.cpu(), a_ref @ b_ref, rtol=1e-4, atol=1e-2)
+    print("fp8 matmul: numerics match the upcast reference")
+
+
+if HAS_E4M3FN:
+    demo_fp8_matmul()
+else:
+    print("fp8 matmul is not available on this product -- skipping (as declared)")

--- a/python/tutorials/precision/02-fp4.py
+++ b/python/tutorials/precision/02-fp4.py
@@ -1,0 +1,106 @@
+"""
+FP4 (E2M1)
+==========
+
+In this tutorial, you will use the FP4 support of FlagTree.
+
+In doing so, you will learn about:
+
+* The packed-uint8 container convention: FP4 has no dtype of its own.
+
+* The in-kernel decode recipe: split the bit fields, rebase the exponent,
+  bitcast to fp16 -- all 16 patterns are exact.
+
+* `tl.dot_scaled` with the "e2m1" format tag as the only matrix entry point.
+
+"""
+
+# %%
+# Packed Containers
+# -----------------
+# FP4 has no dtype of its own: a 4-bit itemsize would break pointer arithmetic
+# and layout analysis. Instead, two E2M1 values live in each uint8 (low nibble
+# first) and the container moves through ordinary byte paths without unpacking.
+# Decoding is a three-step bit recipe: split the fields, rebase the exponent
+# (bias 1 -> 15), and bitcast to fp16. All 16 patterns are exact.
+
+import warnings
+
+import torch
+
+import triton
+import triton.language as tl
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+E2M1_VALUES = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0])
+
+
+def decode_e2m1(nibbles):
+    sign = torch.where(nibbles >> 3 != 0, -1.0, 1.0)
+    return sign * E2M1_VALUES[(nibbles & 0x7).long()]
+
+
+@triton.jit
+def fp4_decode_kernel(packed_ptr, out_ptr, BLOCK: tl.constexpr):
+    offs = tl.arange(0, BLOCK)
+    packed = tl.load(packed_ptr + offs)
+    nib = tl.interleave(packed & 0xF, packed >> 4).to(tl.uint16)  # low nibble first
+    s, e, m = nib >> 3, (nib >> 1) & 0x3, nib & 0x1
+    bits = (s << 15) | tl.where(e == 0, m * 0x3800, ((e + 14) << 10) | (m << 9))
+    tl.store(out_ptr + tl.arange(0, 2 * BLOCK), bits.to(tl.float16, bitcast=True))
+
+
+def demo_fp4_decode():
+    packed = torch.arange(256, dtype=torch.uint8).to(DEVICE)
+    out = torch.empty(512, dtype=torch.float16, device=DEVICE)
+    fp4_decode_kernel[(1, )](packed, out, BLOCK=256)
+    nibbles = torch.stack([packed.cpu() & 0xF, packed.cpu() >> 4], dim=-1).reshape(-1)
+    assert torch.equal(out.cpu().float(), decode_e2m1(nibbles))
+    print("fp4 decode: all 256 byte patterns (512 nibbles) match the E2M1 table")
+
+
+demo_fp4_decode()
+
+# %%
+# FP4 Matmul via `tl.dot_scaled`
+# ------------------------------
+# A packed container fed to plain `tl.dot` is just a uint8 tensor and is
+# rejected by the integer rules. The only matrix entry point is
+# `tl.dot_scaled`, where the "e2m1" format tag gives the container its
+# semantics. Scales use the e8m0 format (127 encodes 1.0). Products without a
+# native scaled-MMA path decompose to a promoted dot and warn at compile time,
+# declared native=false, so silent degradation cannot happen.
+
+
+@triton.jit
+def fp4_matmul_kernel(a_ptr, as_ptr, b_ptr, c_ptr, BM: tl.constexpr, BN: tl.constexpr, BK: tl.constexpr):
+    offs_m = tl.arange(0, BM)
+    offs_n = tl.arange(0, BN)
+    offs_k = tl.arange(0, BK)
+    a = tl.load(a_ptr + offs_m[:, None] * (BK // 2) + tl.arange(0, BK // 2)[None, :])  # packed uint8
+    b = tl.load(b_ptr + offs_k[:, None] * BN + offs_n[None, :])  # bf16
+    a_scale = tl.load(as_ptr + offs_m[:, None] * (BK // 32) + tl.arange(0, BK // 32)[None, :])
+    c = tl.dot_scaled(a, a_scale, "e2m1", b, None, "bf16")
+    tl.store(c_ptr + offs_m[:, None] * BN + offs_n[None, :], c)
+
+
+def demo_fp4_matmul():
+    bm = bn = bk = 64
+    a_packed = torch.randint(0, 256, (bm, bk // 2), dtype=torch.uint8, device=DEVICE)
+    b = (torch.rand(bk, bn, device=DEVICE) * 4 - 2).to(torch.bfloat16)
+    ones = torch.full((bm, bk // 32), 127, dtype=torch.uint8, device=DEVICE)  # e8m0 for 1.0
+    c = torch.empty((bm, bn), dtype=torch.float32, device=DEVICE)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fp4_matmul_kernel[(1, )](a_packed, ones, b, c, BM=bm, BN=bn, BK=bk)
+    for msg in dict.fromkeys(str(w.message) for w in caught):
+        print(f"compile-time warning: {msg}")
+    nibbles = torch.stack([a_packed.cpu() & 0xF, a_packed.cpu() >> 4], dim=-1).reshape(bm, bk)
+    a_ref = decode_e2m1(nibbles)
+    ref = a_ref @ b.cpu().to(torch.float32)
+    torch.testing.assert_close(c.cpu(), ref, rtol=2e-2, atol=1e-1)
+    print("fp4 dot_scaled: numerics match the decode-table reference")
+
+
+demo_fp4_matmul()

--- a/third_party/ppu/backend/compiler.py
+++ b/third_party/ppu/backend/compiler.py
@@ -19,7 +19,7 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from triton.backends.compiler import BaseBackend, GPUTarget, Language
+from triton.backends.compiler import BaseBackend, DotCap, DotSupport, GPUTarget, Language
 from triton._C.libtriton import ir, passes, llvm, ppu
 try:
     from triton._C.libtriton import tle
@@ -34,7 +34,6 @@ from types import ModuleType
 import hashlib
 import re
 import tempfile
-import signal
 import os
 import subprocess
 from pathlib import Path
@@ -81,6 +80,59 @@ def min_dot_size(target: GPUTarget):
             return (1, 1, 16)
 
     return check_dot_compatibility
+
+
+# Whole-byte dtypes covered by the inherited async-copy/descriptor movement paths
+_MOVEMENT_DTYPES = ("fp8e4nv", "fp8e5", "fp8e4b15", "int8", "uint8", "int16", "uint16", "int32", "uint32", "int64",
+                    "uint64", "fp16", "bf16", "fp32", "fp64")
+
+# fp8e4b15 is upcast to f16 by the common semantic layer before resolve_dot
+# runs (upstream legacy behavior), so it never reaches these rules
+_FP8_DOT_DTYPES = ("fp8e4nv", "fp8e5")
+_NATIVE_SAME_TYPE_DOT_DTYPES = ("fp16", "bf16", "fp32", "fp64")
+
+
+def _product_name(capability: int) -> str:
+    return "PPU 810E (cap80)" if capability == 80 else f"PPU (cap{capability})"
+
+
+def _make_resolve_dot(capability: int):
+    """resolve_dot rule: INT8xINT8->INT32 is native; FP8 dot is native
+    from cap89, and a preserved FP16-promotion path (EMULATED) below;
+    every other combination is a compile-time error."""
+    product = _product_name(capability)
+
+    def resolve_dot(a_dtype, b_dtype, acc_dtype, M, N, K):
+        if a_dtype == "int8" and b_dtype == "int8":
+            return DotCap(DotSupport.NATIVE)
+        if a_dtype in _FP8_DOT_DTYPES and b_dtype in _FP8_DOT_DTYPES:
+            if capability >= 89:
+                return DotCap(DotSupport.NATIVE)
+            return DotCap(DotSupport.EMULATED, diag=f"FP8 dot on {product} is not native: "
+                          "emulated via FP16 promotion (native=false)")
+        if a_dtype == b_dtype and a_dtype in _NATIVE_SAME_TYPE_DOT_DTYPES:
+            return DotCap(DotSupport.NATIVE)
+        return DotCap(
+            DotSupport.UNSUPPORTED, diag=f"tl.dot: {a_dtype} x {b_dtype} is not supported on {product}; "
+            "native alternatives: int8 / fp16 / bf16 / fp32 / fp64 dot")
+
+    return resolve_dot
+
+
+def _make_resolve_dot_scaled(capability: int):
+    """resolve_dot_scaled rule: cap89 has a native scaled-MMA path for
+    mxfp4; everything else decomposes to a promoted fp16/bf16 dot and is
+    declared EMULATED with a compile-time warning."""
+    product = _product_name(capability)
+
+    def resolve_dot_scaled(lhs_format, rhs_format):
+        if capability >= 89 and "e2m1" in (lhs_format, rhs_format):
+            return DotCap(DotSupport.NATIVE)
+        return DotCap(
+            DotSupport.EMULATED, diag=f"tl.dot_scaled ({lhs_format} x {rhs_format}) on {product} is not native: "
+            "decomposed to a promoted fp16/bf16 dot (native=false)")
+
+    return resolve_dot_scaled
 
 
 def get_irformatter():
@@ -162,6 +214,10 @@ class HGGCOptions:
     launch_cooperative_grid: bool = False
     launch_pdl: bool = False
     supported_fp8_dtypes: Tuple[str] = ("fp8e5", "fp8e4b15")
+    supported_fp8_cast_dtypes: Tuple[str] = ()
+    custom_cast_fp8_dtypes: Tuple[str] = ("fp8e4b15", )
+    async_copy_dtypes: Tuple[str] = ()
+    descriptor_dtypes: Tuple[str] = ()
     deprecated_fp8_dot_operand_dtypes: Tuple[str] = ()
     default_dot_input_precision: str = "tf32"
     allowed_dot_input_precisions: Tuple[str] = ("tf32", "tf32x3", "ieee", 'bf16x3', 'bf16x6')
@@ -228,9 +284,23 @@ class PPUBackend(BaseBackend):
 
         if "supported_fp8_dtypes" not in args:
             supported_fp8_dtypes = set(HGGCOptions.supported_fp8_dtypes)
-            if capability >= 89:
+            if capability >= 80:
+                # E4M3FN: cast is native from cap89, software on cap80
                 supported_fp8_dtypes.add("fp8e4nv")
             args["supported_fp8_dtypes"] = tuple(sorted(supported_fp8_dtypes))
+
+        if "supported_fp8_cast_dtypes" not in args:
+            # every declared fp8 dtype has a hardware or software cast lowering
+            args["supported_fp8_cast_dtypes"] = args["supported_fp8_dtypes"]
+
+        if "custom_cast_fp8_dtypes" not in args:
+            # cap80 has no e4m3 cvt instructions; fp8e4nv casts go through software
+            args["custom_cast_fp8_dtypes"] = ("fp8e4b15", "fp8e4nv") if capability < 89 else ("fp8e4b15", )
+
+        if "async_copy_dtypes" not in args:
+            args["async_copy_dtypes"] = _MOVEMENT_DTYPES
+        if "descriptor_dtypes" not in args:
+            args["descriptor_dtypes"] = _MOVEMENT_DTYPES
 
         if "deprecated_fp8_dot_operand_dtypes" not in args:
             if capability >= 90:
@@ -253,7 +323,13 @@ class PPUBackend(BaseBackend):
     def get_codegen_implementation(self, options):
         import triton.language.extra.ppu as ppu
         capability = int(self._parse_arch(options.arch))
-        codegen_fns = {"convert_custom_types": ppu.convert_custom_float8, "min_dot_size": min_dot_size(self.target)}
+        sw_cast = "fp8e4nv" in options.custom_cast_fp8_dtypes
+        codegen_fns = {
+            "convert_custom_types": ppu.convert_custom_float8_sub89 if sw_cast else ppu.convert_custom_float8,
+            "min_dot_size": min_dot_size(self.target),
+            "resolve_dot": _make_resolve_dot(capability),
+            "resolve_dot_scaled": _make_resolve_dot_scaled(capability),
+        }
         return codegen_fns
 
     def get_module_map(self) -> Dict[str, ModuleType]:
@@ -535,6 +611,7 @@ please share the reproducer above with Triton project.
             fsrc.name = fsrcformatted
 
             fbin = fsrc.name + ".o"
+            log_file = fsrc.name + ".log"
 
             ppullc_cmd = [
                 ppullc,

--- a/third_party/ppu/language/ppu/__init__.py
+++ b/third_party/ppu/language/ppu/__init__.py
@@ -1,6 +1,6 @@
 from . import libdevice
 
-from .utils import (globaltimer, num_threads, num_warps, smid, convert_custom_float8)
+from .utils import (globaltimer, num_threads, num_warps, smid, convert_custom_float8, convert_custom_float8_sub89)
 
 __all__ = [
     "libdevice",
@@ -9,4 +9,5 @@ __all__ = [
     "num_warps",
     "smid",
     "convert_custom_float8",
+    "convert_custom_float8_sub89",
 ]

--- a/third_party/ppu/language/ppu/utils.py
+++ b/third_party/ppu/language/ppu/utils.py
@@ -123,3 +123,100 @@ def convert_custom_float8_internal(arg, dst_ty, fp_downcast_rounding, has_minx2,
 @core.builtin
 def convert_custom_float8(arg, dst_ty, fp_downcast_rounding=None, _semantic=None):
     return convert_custom_float8_internal(arg, dst_ty, fp_downcast_rounding, has_minx2=True, _semantic=_semantic)
+
+
+# ----- FP8E4M3FN (fp8e4nv) software cast, capability < 89 ------
+# cap80 has no e4m3 cvt instructions; the numerical cast is implemented with
+# ordinary integer/float ops. Rounding is strict RTNE (ties-to-even, with the
+# mantissa carry propagating into the exponent) or RTZ, saturation is
+# satfinite (|x| > 448 -> 0x7E), NaN maps to 0x7F, and 0x7F/0xFF decode to NaN.
+
+
+def _rounding_is_rtz(fp_downcast_rounding):
+    # accepts the ir.ROUNDING_MODE enum (from semantic.cast) or the string spelling
+    if fp_downcast_rounding is None:
+        return False
+    if isinstance(fp_downcast_rounding, str):
+        return fp_downcast_rounding.lower() == "rtz"
+    from triton._C.libtriton import ir
+    return fp_downcast_rounding == ir.ROUNDING_MODE.RTZ
+
+
+@core.builtin
+def _upcast_e4nv_to_f16(arg, _semantic=None):
+    """Software OCP E4M3FN -> fp16; exact for every one of the 256 encodings."""
+    sem = _semantic
+    u = arg.to(core.uint8, bitcast=True, _semantic=sem).to(core.uint16, _semantic=sem)
+    s = sem.shl(sem.and_(u, 0x0080), 8)
+    em = sem.and_(u, 0x007F)
+    e = sem.lshr(em, 3)
+    m = sem.and_(em, 0x0007)
+    # normal (e >= 1): f16 bits = ((e - 7 + 15) << 10) | (m << 7)
+    normal = sem.or_(sem.shl(sem.add(e, 8, False), 10), sem.shl(m, 7))
+    # subnormal (e == 0): value = m * 2^-9, exact via f32 then truncation to f16
+    sub_f = sem.mul(m.to(core.float32, _semantic=sem), 2.0**-9, False)
+    sub_bits = sub_f.to(core.float16, _semantic=sem).to(core.uint16, bitcast=True, _semantic=sem)
+    body = sem.where(sem.equal(e, 0), sub_bits, normal)
+    body = sem.where(sem.equal(em, 0x007F), 0x7E00, body)  # NaN codes 0x7F/0xFF
+    return sem.or_(body, s).to(core.float16, bitcast=True, _semantic=sem)
+
+
+@core.builtin
+def _downcast_f32_to_e4nv(arg, rtz, _semantic=None):
+    """Software fp32 -> OCP E4M3FN with single rounding (RTNE or RTZ) and
+    satfinite saturation; bit-exact against the format's reference encoder."""
+    sem = _semantic
+    b = arg.to(core.int32, bitcast=True, _semantic=sem)
+    sign = sem.shl(sem.and_(sem.lshr(b, 31), 1), 7)
+    ab = sem.and_(b, 0x7FFFFFFF)
+    is_nan = sem.greater_than(ab, 0x7F800000)
+    e32 = sem.lshr(ab, 23)
+    m32 = sem.and_(ab, 0x7FFFFF)
+    # E: biased target exponent (bias 7); k: mantissa bits to drop (20 for the
+    # normal range, up to 6 more in the subnormal range; >26 always rounds to 0)
+    E = sem.sub(e32, 120, False)
+    pn = core.PropagateNan.NONE
+    k = sem.add(sem.minimum(sem.maximum(sem.sub(1, E, False), 0, pn), 6, pn), 20, False)
+    sig = sem.or_(m32, 0x800000)
+    keep = sem.lshr(sig, k)
+    if rtz:
+        pass
+    else:  # strict RTNE: round up on >half, or ==half when the kept lsb is odd
+        rem = sem.and_(sig, sem.sub(sem.shl(1, k), 1, False))
+        half = sem.shl(1, sem.sub(k, 1, False))
+        up = sem.or_(sem.greater_than(rem, half), sem.and_(sem.equal(rem, half), sem.equal(sem.and_(keep, 1), 1)))
+        keep = sem.add(keep, up.to(core.int32, _semantic=sem), False)
+    # (E<<3) + keep - 8 folds the mantissa carry into the exponent; the
+    # subnormal branch is plain `keep` (keep == 8 becomes the minimum normal)
+    expmant = sem.where(sem.greater_equal(E, 1), sem.sub(sem.add(sem.shl(E, 3), keep, False), 8, False), keep)
+    expmant = sem.minimum(expmant, 0x7E, pn)  # satfinite (|x| > 448, inf)
+    res = sem.or_(expmant, sign)
+    res = sem.where(is_nan, 0x7F, res)
+    return res.to(core.uint8, _semantic=sem).to(core.float8e4nv, bitcast=True, _semantic=sem)
+
+
+@core.builtin
+def convert_custom_float8_sub89(arg, dst_ty, fp_downcast_rounding=None, _semantic=None):
+    """convert_custom_types implementation for capability < 89: the fp8e4b15
+    path of convert_custom_float8 plus the software fp8e4nv cast."""
+    src_sca = arg.type.scalar
+    dst_sca = dst_ty.scalar
+    if src_sca.is_fp8e4b15() or dst_sca.is_fp8e4b15():
+        return convert_custom_float8_internal(arg, dst_ty, fp_downcast_rounding, has_minx2=True, _semantic=_semantic)
+    if src_sca.is_fp8e4nv():
+        up = _upcast_e4nv_to_f16(arg, _semantic=_semantic)
+        if dst_sca.is_fp16():
+            return up
+        if dst_sca.is_fp32() or dst_sca.is_bf16() or dst_sca.is_fp64():
+            return up.to(dst_sca, _semantic=_semantic)
+        if dst_sca.is_fp8e5():
+            rounding = "rtz" if _rounding_is_rtz(fp_downcast_rounding) else "rtne"
+            return up.to(dst_sca, fp_downcast_rounding=rounding, _semantic=_semantic)
+        raise ValueError(f"cast from fp8e4nv to {dst_sca} is not supported on this product")
+    if dst_sca.is_fp8e4nv():
+        if not src_sca.is_floating():
+            raise ValueError(f"cast from {src_sca} to fp8e4nv is not supported on this product")
+        # f16/bf16 widen exactly (single rounding); an fp64 source rounds twice
+        x = arg if src_sca.is_fp32() else arg.to(core.float32, _semantic=_semantic)
+        return _downcast_f32_to_e4nv(x, _rounding_is_rtz(fp_downcast_rounding), _semantic=_semantic)
+    raise ValueError(f"unsupported custom fp8 conversion from {src_sca} to {dst_sca}")

--- a/third_party/ppu/lib/TritonPPUGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/ppu/lib/TritonPPUGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -217,12 +217,55 @@ static const Fp8ConversionDesc Bf16_to_Fp8E5M2(bool hasNativeFP) {
   return ret;
 }
 
+// Software E4M3FN -> FP16 for capability < 89 (no e4m3 cvt instructions):
+// reads 4 e4m3 bytes from $2 and leaves 4 f16 values in v0/v1. Embedding
+// exp+mantissa at the fp16 position gives value * 2^-8 (linear for subnormals
+// too), one multiply by 256 rebiases; NaN codes (embedded as 480) get masked.
+static const char Fp8E4M3Nv_to_Fp16_SwCore[] =
+    ".reg .b32 a<2>, b<2>, t<2>, u<2>, w<2>, m<2>;\n"
+    ".reg .b32 v<2>, e256;                        \n"
+    "ppu.mov.u32 e256, 0x5c005c00;                \n" // 256.0 x f16x2
+    "ppu.prmt.b32 a0, 0, $2, 0x5140;              \n" // a0 = 0xf300f400
+    "ppu.prmt.b32 a1, 0, $2, 0x7362;              \n" // a1 = 0xf100f200
+    "ppu.lop3.b32 b0, a0, 0x7f007f00, 0, 0xc0;    \n" // strip sign
+    "ppu.lop3.b32 b1, a1, 0x7f007f00, 0, 0xc0;    \n"
+    "ppu.shr.b32  b0, b0, 1;                      \n" // em<<8 -> em<<7
+    "ppu.shr.b32  b1, b1, 1;                      \n"
+    "ppu.mul.rn.f16x2 b0, b0, e256;               \n" // rebias by 2^8
+    "ppu.mul.rn.f16x2 b1, b1, e256;               \n"
+    "ppu.lop3.b32 b0, b0, 0x80008000, a0, 0xf8;   \n" // restore sign
+    "ppu.lop3.b32 b1, b1, 0x80008000, a1, 0xf8;   \n"
+    "ppu.and.b32 t0, a0, 0x7f007f00;              \n" // NaN lanes have
+    "ppu.and.b32 t1, a1, 0x7f007f00;              \n" // em == 0x7f
+    "ppu.add.u32 u0, t0, 0x01000100;              \n"
+    "ppu.add.u32 u1, t1, 0x01000100;              \n"
+    "ppu.and.b32 w0, u0, 0x80008000;              \n"
+    "ppu.and.b32 w1, u1, 0x80008000;              \n"
+    "ppu.shr.b32 w0, w0, 15;                      \n"
+    "ppu.shr.b32 w1, w1, 15;                      \n"
+    "ppu.mul.lo.u32 m0, w0, 0xffff;               \n" // 0/1 -> lane mask
+    "ppu.mul.lo.u32 m1, w1, 0xffff;               \n"
+    "ppu.lop3.b32 v0, b0, m0, 0x7e007e00, 0xb8;   \n" // NaN -> 0x7e00
+    "ppu.lop3.b32 v1, b1, m1, 0x7e007e00, 0xb8;   \n";
+
 // Fp8E4M3 (x2) -> Fp16 (x2) (packed)
-static const Fp8ConversionDesc Fp8E4M3Nv_to_Fp16 = {
-    "{ \n"
-    "ppu.cvt.rn.f16x2.e4m3x2 $0, $1; \n"
-    "}",
-    16, 32, 2};
+static const Fp8ConversionDesc Fp8E4M3Nv_to_Fp16(bool hasNativeFP) {
+  Fp8ConversionDesc ret;
+  if (!hasNativeFP) {
+    ret = {std::string("{                                            \n") +
+               Fp8E4M3Nv_to_Fp16_SwCore +
+               "ppu.mov.b32 $0, v0;                          \n"
+               "ppu.mov.b32 $1, v1;                          \n"
+               "}",
+           32, 32, 4};
+  } else {
+    ret = {"{ \n"
+           "ppu.cvt.rn.f16x2.e4m3x2 $0, $1; \n"
+           "}",
+           16, 32, 2};
+  }
+  return ret;
+}
 
 // Fp16 (x2) -> Fp8E4M3 (x2) (packed)
 static const Fp8ConversionDesc Fp16_to_Fp8E4M3Nv = {
@@ -233,22 +276,26 @@ static const Fp8ConversionDesc Fp16_to_Fp8E4M3Nv = {
 
 static const Fp8ConversionDesc Fp8E4M3Nv_to_Bf16(bool hasNativeFP) {
   Fp8ConversionDesc ret;
-  // Fp8E4M3 (x2) -> Fp16 (x2) (packed)
   if (!hasNativeFP) {
-    ret = {"{                                       \n"
-           ".reg .b32 a;                            \n"
-           ".reg .f16 a<2>;                         \n"
-           ".reg .f32 b<2>;                         \n"
-           ".reg .b16 c<2>;                         \n"
-           "ppu.cvt.rn.f16x2.e4m3x2 a, $1;              \n"
-           "ppu.mov.b32 {a0, a1}, a;                    \n"
-           "ppu.cvt.f32.f16 b0, a0;                     \n"
-           "ppu.cvt.f32.f16 b1, a1;                     \n"
-           "ppu.cvt.rn.bf16.f32 c0, b0;                 \n"
-           "ppu.cvt.rn.bf16.f32 c1, b1;                 \n"
-           "ppu.mov.b32 $0, {c0, c1};                   \n"
-           "}",
-           16, 32, 2};
+    // software E4M3FN -> FP16 core plus exact f16 -> f32 -> bf16 cvt chains
+    ret = {std::string("{                                            \n") +
+               Fp8E4M3Nv_to_Fp16_SwCore +
+               ".reg .b16 h<4>, r<4>;                        \n"
+               ".reg .f32 f<4>;                              \n"
+               "ppu.mov.b32 {h0, h1}, v0;                    \n"
+               "ppu.mov.b32 {h2, h3}, v1;                    \n"
+               "ppu.cvt.f32.f16 f0, h0;                      \n"
+               "ppu.cvt.f32.f16 f1, h1;                      \n"
+               "ppu.cvt.f32.f16 f2, h2;                      \n"
+               "ppu.cvt.f32.f16 f3, h3;                      \n"
+               "ppu.cvt.rn.bf16.f32 r0, f0;                  \n"
+               "ppu.cvt.rn.bf16.f32 r1, f1;                  \n"
+               "ppu.cvt.rn.bf16.f32 r2, f2;                  \n"
+               "ppu.cvt.rn.bf16.f32 r3, f3;                  \n"
+               "ppu.mov.b32 $0, {r0, r1};                    \n"
+               "ppu.mov.b32 $1, {r2, r3};                    \n"
+               "}",
+           32, 32, 4};
   } else {
     ret = {"{                                       \n"
            ".reg .b32 a;                            \n"
@@ -461,10 +508,12 @@ struct FpToFpOpConversion
 
     auto undefRounding = static_cast<RoundingMode>(-1);
 
-    static DenseMap<std::tuple<TypeID, TypeID, RoundingMode>, Fp8ConversionDesc>
+    // entries depend on computeCapability, so the map must not be static
+    const DenseMap<std::tuple<TypeID, TypeID, RoundingMode>, Fp8ConversionDesc>
         srcMap = {
             // F8 -> F16
-            {{F8E4M3TyID, F16TyID, undefRounding}, Fp8E4M3Nv_to_Fp16},
+            {{F8E4M3TyID, F16TyID, undefRounding},
+             Fp8E4M3Nv_to_Fp16(computeCapability >= 89)},
             {{F8E5M2TyID, F16TyID, undefRounding},
              Fp8E5M2_to_Fp16(computeCapability >= 89)},
             {{F16TyID, F8E4M3TyID, RoundingMode::RTNE}, Fp16_to_Fp8E4M3Nv},
@@ -498,10 +547,12 @@ struct FpToFpOpConversion
       llvm::errs() << "\n";
       llvm::report_fatal_error("Unsupported rounding mode for conversion.");
     }
-    if (computeCapability < 89 && (llvm::isa<Float8E4M3FNType>(srcTy) ||
-                                   llvm::isa<Float8E4M3FNType>(dstTy))) {
-      llvm::report_fatal_error("Conversion from/to f8e4m3nv is only supported "
-                               "on compute capability >= 89\n");
+    if (computeCapability < 89 && llvm::isa<Float8E4M3FNType>(dstTy)) {
+      // downcasts to f8e4m3nv are implemented in the frontend
+      // (convert_custom_types) below capability 89
+      llvm::report_fatal_error(
+          "Conversion to f8e4m3nv is only supported on compute capability >= "
+          "89; on this target the frontend lowers such casts in software\n");
     }
     auto convDesc = srcMap.lookup(key);
     return {makeConverterFromTIX(

--- a/third_party/ppu/lib/TritonPPUGPUToLLVM/Fp4ToFpOpToLLVM.cpp
+++ b/third_party/ppu/lib/TritonPPUGPUToLLVM/Fp4ToFpOpToLLVM.cpp
@@ -108,8 +108,10 @@ static Value createInlineAsmUpcast(Location loc, RewriterBase &rewriter,
 namespace {
 class Fp4ToFpOpPattern : public ConvertOpToLLVMPattern<Fp4ToFpOp> {
 public:
-  Fp4ToFpOpPattern(LLVMTypeConverter &typeConverter, PatternBenefit benefit)
-      : ConvertOpToLLVMPattern<Fp4ToFpOp>(typeConverter, benefit) {}
+  Fp4ToFpOpPattern(LLVMTypeConverter &typeConverter, int computeCapability,
+                   PatternBenefit benefit)
+      : ConvertOpToLLVMPattern<Fp4ToFpOp>(typeConverter, benefit),
+        computeCapability(computeCapability) {}
 
   LogicalResult
   matchAndRewrite(Fp4ToFpOp op, OpAdaptor adaptor,
@@ -120,6 +122,10 @@ public:
     auto elemType = op.getType().getElementType();
     assert(elemType == f16_ty || elemType == bf16_ty);
     bool toFp16 = elemType == f16_ty;
+    // FP4ToFP16Tix needs the e4m3 cvt instruction (capability >= 89); below
+    // that, upcast through the bf16 table and rebase the exponent to f16 with
+    // integer ops (every E2M1 value is exact in both formats).
+    bool viaBf16 = toFp16 && computeCapability < 89;
 
     auto xVals = unpackLLElements(loc, adaptor.getSrc(), rewriter);
 
@@ -139,13 +145,27 @@ public:
       packedVec = b.insert_element(packedVec, v3, b.i32_val(3));
       SmallVector<Type> rets(4, i32_ty);
       Type retType = struct_ty(rets);
-      Value ret =
-          createInlineAsmUpcast(loc, rewriter, toFp16, retType, packedVec);
+      Value ret = createInlineAsmUpcast(loc, rewriter, toFp16 && !viaBf16,
+                                        retType, packedVec);
       for (int i = 0; i < 4; i++) {
         Value extractI32 = b.extract_val(ret, i);
-        Value elements = b.bitcast(extractI32, vec_ty(elemType, 2));
-        results.push_back(b.extract_element(elements, b.i32_val(0)));
-        results.push_back(b.extract_element(elements, b.i32_val(1)));
+        if (viaBf16) {
+          Value halves = b.bitcast(extractI32, vec_ty(i16_ty, 2));
+          for (int j = 0; j < 2; j++) {
+            Value v = b.extract_element(halves, b.i32_val(j));
+            Value sign = b.and_(v, b.i16_val(0x8000));
+            Value em = b.and_(v, b.i16_val(0x7fff));
+            // bf16 -> f16 for exact normals: ((e-127+15) << 10) | (m << 3)
+            Value shifted = b.shl(b.sub(em, b.i16_val(112 << 7)), b.i16_val(3));
+            Value isZero = b.icmp_eq(em, b.i16_val(0));
+            Value body = b.select(isZero, b.i16_val(0), shifted);
+            results.push_back(b.bitcast(b.or_(body, sign), f16_ty));
+          }
+        } else {
+          Value elements = b.bitcast(extractI32, vec_ty(elemType, 2));
+          results.push_back(b.extract_element(elements, b.i32_val(0)));
+          results.push_back(b.extract_element(elements, b.i32_val(1)));
+        }
       }
     }
 
@@ -154,11 +174,14 @@ public:
     rewriter.replaceOp(op, result);
     return success();
   }
+
+private:
+  int computeCapability;
 };
 } // anonymous namespace
 
 void mlir::triton::ppu::populateFp4ToFpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
-    PatternBenefit benefit) {
-  patterns.add<Fp4ToFpOpPattern>(typeConverter, benefit);
+    int computeCapability, PatternBenefit benefit) {
+  patterns.add<Fp4ToFpOpPattern>(typeConverter, computeCapability, benefit);
 }

--- a/third_party/ppu/lib/TritonPPUGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/ppu/lib/TritonPPUGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -57,6 +57,7 @@ void populateElementwiseOpToLLVMPatterns(
 
 void populateFp4ToFpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                    RewritePatternSet &patterns,
+                                   int computeCapability,
                                    PatternBenefit benefit);
 
 void populateLoadStoreOpToLLVMPatterns(LLVMTypeConverter &typeConverter,

--- a/third_party/ppu/lib/TritonPPUGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/ppu/lib/TritonPPUGPUToLLVM/TritonGPUToLLVM.cpp
@@ -360,8 +360,8 @@ struct ConvertTritonGPUToLLVMPPU
                                                       patterns, benefit);
     mlir::triton::populateMakeRangeOpToLLVMPattern(typeConverter, targetInfo,
                                                    patterns, benefit);
-    mlir::triton::ppu::populateFp4ToFpToLLVMPatterns(typeConverter, patterns,
-                                                     benefit);
+    mlir::triton::ppu::populateFp4ToFpToLLVMPatterns(
+        typeConverter, patterns, computeCapability, benefit);
     mlir::triton::populateInstrumentationToLLVMPatterns(
         typeConverter, targetInfo, patterns, benefit);
 

--- a/third_party/ppu/python/test/unit/language/test_compile_errors.py
+++ b/third_party/ppu/python/test/unit/language/test_compile_errors.py
@@ -363,6 +363,10 @@ def test_fp8_support(fresh_triton_cache, dtype):
             warning_dtypes.append(tl.float8e4b15)
         if cc >= (8, 9):
             supported_dtypes.append(tl.float8e4nv)
+        elif is_ppu() and cc >= (8, 0):
+            # On PPU cap80-88, fp8e4nv compiles but tl.dot is emulated via FP16 promotion
+            supported_dtypes.append(tl.float8e4nv)
+            warning_dtypes.append(tl.float8e4nv)
     elif is_hip():
         supported_dtypes += [tl.float8e4nv, tl.float8e4b8, tl.float8e5b16]
         if is_hip_cdna4():
@@ -374,7 +378,9 @@ def test_fp8_support(fresh_triton_cache, dtype):
         tl.dot(a, a)
 
     if dtype in warning_dtypes:
-        if is_cuda() or is_ppu():
+        if dtype == tl.float8e4nv:
+            ctx = pytest.warns(UserWarning, match=r"emulated via FP16 promotion")
+        elif is_cuda() or is_ppu():
             ctx = pytest.warns(UserWarning,
                                match=r"the use of fp8e4b15 is deprecated on Hopper and later architectures")
         elif is_hip_cdna4():

--- a/third_party/ppu/python/test/unit/language/test_conversions.py
+++ b/third_party/ppu/python/test/unit/language/test_conversions.py
@@ -276,7 +276,9 @@ def test_typeconvert_upcast(src_dtype, dst_dtype, device):
     # On HIP, fp8e4nv upcasting to fp32 is only supported on CDNA4, and
     # fp8e4nv upcasting to bf16 and fp16 is only supported on CDNA3 and CDNA4.
     if is_cuda() or is_ppu():
-        if ((src_dtype == 'float8e4nv' and torch.cuda.get_device_capability(0) < (8, 9))
+        # On PPU, fp8e4nv casts are software-lowered from cap80
+        e4nv_error_cc = (8, 0) if is_ppu() else (8, 9)
+        if ((src_dtype == 'float8e4nv' and torch.cuda.get_device_capability(0) < e4nv_error_cc)
             or src_dtype in ('float8e4b8', 'float8e5b16')):
             # If the dtype should error out in the given device, we assert that and return
             with pytest.raises(triton.CompilationError, match="not supported in this architecture"):
@@ -337,7 +339,10 @@ def test_typeconvert_downcast(src_dtype, dst_dtype, rounding, max_repr, device):
             pytest.skip("non-float32 downcast tests only supported on NVGPU with compute capability 9.0+")
 
         if dst_dtype in ('float8e5', 'float8e4nv') and rounding == 'rtne' and torch.cuda.get_device_capability(0) < (9, 0):
-            pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
+            # On PPU cap80-88, the software fp8e4nv downcast rounds once from f32 with
+            # strict RTNE; cap89+ native cvt may double-round via f16, so keep it skipped
+            if not (is_ppu() and dst_dtype == 'float8e4nv' and (8, 0) <= torch.cuda.get_device_capability(0) < (8, 9)):
+                pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
 
         if dst_dtype in ('float8e5b16', 'float8e4b8') and rounding == 'rtne':
             pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on AMDGPU CDNA3")
@@ -371,7 +376,9 @@ def test_typeconvert_downcast_clamping(src_dtype, dst_dtype, mode, device, round
             pytest.skip("non-float32 downcast tests only supported on NVGPU with compute capability 9.0+")
 
         if dst_dtype in ('float8e5', 'float8e4nv') and rounding == 'rtne' and torch.cuda.get_device_capability(0) < (9, 0):
-            pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
+            # On PPU cap80-88, the software fp8e4nv downcast is satfinite with strict RTNE
+            if not (is_ppu() and dst_dtype == 'float8e4nv' and (8, 0) <= torch.cuda.get_device_capability(0) < (8, 9)):
+                pytest.skip(f"{dst_dtype} downcast with RTNE rounding tests only supported on NVGPU with compute capability 9.0+")
 
     converter = {
         tl.float8e4nv: torch.float8_e4m3fn,


### PR DESCRIPTION
> **Depends on #1112** — this branch is stacked on `feature/precision-core`; the first commit is that PR. Please review only the second commit (`third_party/ppu/` only). Will rebase once #1112 merges.

## Summary

PPU implementation of the low-precision float capability contract from #1112.

- **`backend/compiler.py`**: per-capability declarations — `fp8e4nv` is declared from cap80 (cast is native from cap89, software below); `supported_fp8_cast_dtypes`, `custom_cast_fp8_dtypes`, `async_copy_dtypes` / `descriptor_dtypes` field family; `resolve_dot` / `resolve_dot_scaled` rules (int8 and same-type fp16/bf16/fp32/fp64 native; fp8 dot native from cap89, `EMULATED` via FP16 promotion below; mxfp4 scaled-MMA native from cap89, `EMULATED` decomposition otherwise).
- **`language/ppu/utils.py`**: `convert_custom_float8_sub89` — software OCP E4M3FN cast for capability < 89, exact for all 256 encodings on upcast, strict RTNE/RTZ with satfinite on downcast.
- **`ElementwiseOpToLLVM.cpp`**: software E4M3FN→FP16/BF16 asm core for pass-generated `FpToFp` ops below cap89; the conversion map is no longer `static` since its entries depend on `computeCapability` (latent bug when two capabilities coexist in one process).
- **`Fp4ToFpOpToLLVM.cpp`**: below cap89 the f16 upcast goes through the bf16 table plus an exact integer exponent rebase (every E2M1 value is a normal number in both formats).

## Drive-by fixes

- `backend/compiler.py`: define `log_file` before use — the `dump_compile_log` and compile-error paths referenced an undefined name (NameError on main); drop unused `import signal`.
