### PR TITLE
[BACKEND][MTHREADS] Low-precision float support: resolve_dot capability rules, fp8 dual whitelist, SQMMA/WMMA fp8 lowering fixes

### DIFF
--- a/python/triton/backends/__init__.py
+++ b/python/triton/backends/__init__.py
@@ -158,6 +158,9 @@ class _LanguageExtensions:
     def __getattr__(self, name):
         if name in self._symbols:
             return self._symbols[name]
+        # dunder probes (inspect, copy, is_builtin, ...) must get AttributeError
+        if name.startswith("__") and name.endswith("__"):
+            raise AttributeError(name)
         providers = [(backend_name, getattr(module, name))
                      for backend_name, module in self._get_modules()
                      if hasattr(module, name)]

--- a/python/triton/backends/compiler.py
+++ b/python/triton/backends/compiler.py
@@ -23,7 +23,7 @@
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 from types import ModuleType
 
 
@@ -34,6 +34,31 @@ class GPUTarget(object):
     # Target architecture, e.g., 90 (for cuda compute capability), gfx940 (for hip)
     arch: Union[int, str]
     warp_size: int
+
+
+class DotSupport(Enum):
+    """How a backend supports a dot dtype/format combination."""
+    NATIVE = "native"
+    EMULATED = "emulated"
+    UNSUPPORTED = "unsupported"
+
+
+@dataclass(frozen=True)
+class DotCap:
+    """Answer to a backend `resolve_dot(a_dtype, b_dtype, acc_dtype, M, N, K)` /
+    `resolve_dot_scaled(lhs_format, rhs_format)` codegen-function query: the
+    semantic layer rejects UNSUPPORTED combinations with `diag` as the error
+    message and emits `diag` as a compile-time warning for EMULATED ones."""
+    support: DotSupport
+    diag: Optional[str] = None
+
+    @property
+    def supported(self) -> bool:
+        return self.support is not DotSupport.UNSUPPORTED
+
+    @property
+    def native(self) -> bool:
+        return self.support is DotSupport.NATIVE
 
 
 class Language(Enum):

--- a/python/triton/language/semantic.py
+++ b/python/triton/language/semantic.py
@@ -836,10 +836,21 @@ class TritonSemantic(Generic[TensorTy]):
                                  "Source scalar type is " + str(src_sca_ty) + " and destination type is " +
                                  str(dst_sca_ty))
 
-        if (src_sca_ty.is_fp8e4b15() or dst_sca_ty.is_fp8e4b15()):
-            assert self.builder.codegen_fns.get(
-                "convert_custom_types") is not None, "target doesn't provide conversion for this type."
-            return self.builder.codegen_fns["convert_custom_types"](input, dst_ty, fp_downcast_rounding, _semantic=self)
+        if src_sca_ty.is_fp8() or dst_sca_ty.is_fp8():
+            options = self.builder.options
+            cast_whitelist = getattr(options, "supported_fp8_cast_dtypes", None)
+            if cast_whitelist is not None and src_sca_ty.is_floating() and dst_sca_ty.is_floating():
+                for ty in (src_sca_ty, dst_sca_ty):
+                    if ty.is_fp8() and ty.name not in cast_whitelist:
+                        raise ValueError(f"cast involving type {ty} is not supported in this architecture. "
+                                         f"The supported fp8 cast dtypes are {cast_whitelist}")
+            # Backends declare fp8 dtypes with software casts under "custom_cast_fp8_dtypes";
+            # the default preserves the legacy fp8e4b15-only routing.
+            custom_cast_dtypes = getattr(options, "custom_cast_fp8_dtypes", ("fp8e4b15", ))
+            if src_sca_ty.name in custom_cast_dtypes or dst_sca_ty.name in custom_cast_dtypes:
+                custom_cast = self.builder.codegen_fns.get("convert_custom_types")
+                assert custom_cast is not None, "target doesn't provide conversion for this type."
+                return custom_cast(input, dst_ty, fp_downcast_rounding, _semantic=self)
         # Casting with customized floating types involved: fp8 <=> bf16, fp16, fp32, fp64
         # and non-default rounding modes for downcasting
         if (src_sca_ty.is_fp8() and dst_sca_ty.is_floating()) or \
@@ -1508,10 +1519,12 @@ class TritonSemantic(Generic[TensorTy]):
             max_num_imprecise_acc: int, out_dtype: tl.dtype) -> TensorTy:
         assert lhs.type.is_block() and rhs.type.is_block()
 
+        # resolve_dot backends own the dtype rules (queried once shapes are known)
+        resolve_dot = self.builder.codegen_fns.get("resolve_dot")
         if lhs.dtype.is_fp8() and rhs.dtype.is_fp8():
             # All combinations of supported fp8 x fp8 are permitted
             pass
-        else:
+        elif resolve_dot is None:
             assert lhs.dtype in (tl.int8, tl.uint8, tl.float16, tl.bfloat16, tl.float32,
                                  tl.float64), f"Unsupported lhs dtype {lhs.dtype}"
             assert rhs.dtype in (tl.int8, tl.uint8, tl.float16, tl.bfloat16, tl.float32,
@@ -1551,6 +1564,15 @@ class TritonSemantic(Generic[TensorTy]):
             -2].value, f"First input shape ({lhs.shape}) and second input shape {rhs.shape} are not compatible for matmul (second index of first shape ({lhs.shape[-1].value}) must be equal to first index of second shape ({rhs.shape[-2].value})"
         assert self.builder.codegen_fns.get(
             "min_dot_size") is not None, "target doesn't provide lower shape bounds for dot."
+        if resolve_dot is not None:
+            # queried after the legacy e4b15/fnuz upcasts above so rules see the effective dtypes
+            dot_cap = resolve_dot(lhs.dtype.name, rhs.dtype.name, out_dtype.name, lhs.shape[-2].value,
+                                  rhs.shape[-1].value, lhs.shape[-1].value)
+            if not dot_cap.supported:
+                raise ValueError(dot_cap.diag or f"tl.dot: {lhs.dtype} x {rhs.dtype} is not supported on this product")
+            if not dot_cap.native:
+                warnings.warn(dot_cap.diag or f"tl.dot: {lhs.dtype} x {rhs.dtype} is not native on this "
+                              "product: emulated path (native=false)")
         min_dot_size = self.builder.codegen_fns["min_dot_size"](lhs.type, rhs.type)
         assert lhs.shape[-2].value >= min_dot_size[0] and lhs.shape[-1].value >= min_dot_size[2] \
             and rhs.shape[-1].value >= min_dot_size[1], \
@@ -1650,6 +1672,16 @@ class TritonSemantic(Generic[TensorTy]):
         allowed_formats = {"e2m1", "e4m3", "e5m2", "bf16", "fp16"}
         assert lhs_format in allowed_formats, f"NYI: lhs_format {lhs_format}"
         assert rhs_format in allowed_formats, f"NYI: rhs_format {rhs_format}"
+        # non-native (decomposed) format combinations warn at compile time
+        resolve_dot_scaled = self.builder.codegen_fns.get("resolve_dot_scaled")
+        if resolve_dot_scaled is not None:
+            scaled_cap = resolve_dot_scaled(lhs_format, rhs_format)
+            if not scaled_cap.supported:
+                raise ValueError(scaled_cap.diag
+                                 or f"tl.dot_scaled: {lhs_format} x {rhs_format} is not supported on this product")
+            if not scaled_cap.native:
+                warnings.warn(scaled_cap.diag or f"tl.dot_scaled: {lhs_format} x {rhs_format} is not native "
+                              "on this product: decomposed to an emulated path (native=false)")
         rhs_scale_is_none = rhs_scale is None or (isinstance(rhs_scale, tl.constexpr) and rhs_scale.value is None)
         lhs_scale_is_none = lhs_scale is None or (isinstance(lhs_scale, tl.constexpr) and lhs_scale.value is None)
         lhs = self._bitcast_to_fp_type(lhs, lhs_format)

--- a/python/triton/runtime/interpreter.py
+++ b/python/triton/runtime/interpreter.py
@@ -221,67 +221,123 @@ def _get_np_dtype(tt_dtype):
     return np_types[tt_dtype]
 
 
+def _float_special_kind(dtype):
+    """Special-value convention of a float format:
+    "ieee": inf at e=max/m=0, nan at e=max/m!=0 (fp16/bf16/fp32/fp64/fp8e5)
+    "fn":   no inf; nan is all-ones exponent + all-ones mantissa (fp8e4nv)
+    "fnuz": no inf; nan is the sign bit only (fp8e4b8 / fp8e5b16)
+    "none": neither inf nor nan (fp8e4b15)
+    """
+    return {
+        tl.float8e4nv: "fn",
+        tl.float8e4b8: "fnuz",
+        tl.float8e5b16: "fnuz",
+        tl.float8e4b15: "none",
+    }.get(dtype, "ieee")
+
+
+def _decode_float_to_fp64(bits, dtype):
+    """Decode raw bit patterns of `dtype` into exact float64 values."""
+    if dtype == tl.float64:
+        return bits.view(np.float64).copy()
+    if dtype == tl.float32:
+        return bits.view(np.float32).astype(np.float64)
+    if dtype == tl.float16:
+        return bits.view(np.float16).astype(np.float64)
+    if dtype == tl.bfloat16:
+        return (bits.astype(np.uint32) << 16).view(np.float32).astype(np.float64)
+    mw = dtype.fp_mantissa_width
+    ew = dtype.primitive_bitwidth - mw - 1
+    bias = dtype.exponent_bias
+    kind = _float_special_kind(dtype)
+    b = bits.astype(np.int64)
+    sign = np.where((b >> (mw + ew)) & 1, -1.0, 1.0)
+    e = (b >> mw) & ((1 << ew) - 1)
+    m = b & ((1 << mw) - 1)
+    normal = np.ldexp(1.0 + m / (1 << mw), (e - bias).astype(np.int32))
+    subnormal = np.ldexp(m / (1 << mw), np.int32(1 - bias))
+    val = sign * np.where(e == 0, subnormal, normal)
+    e_max = (1 << ew) - 1
+    if kind == "ieee":
+        val = np.where((e == e_max) & (m == 0), sign * np.inf, val)
+        val = np.where((e == e_max) & (m != 0), np.nan, val)
+    elif kind == "fn":
+        val = np.where((e == e_max) & (m == (1 << mw) - 1), np.nan, val)
+    elif kind == "fnuz":
+        val = np.where(b == (1 << (mw + ew)), np.nan, val)
+    return val
+
+
+def _encode_fp64_to_float(val, dtype, rounding_mode):
+    """Encode float64 values into raw bit patterns of `dtype` with strict
+    RTNE/RTZ rounding; formats without inf saturate to max finite."""
+    mw = dtype.fp_mantissa_width
+    ew = dtype.primitive_bitwidth - mw - 1
+    bias = dtype.exponent_bias
+    kind = _float_special_kind(dtype)
+    e_max = (1 << ew) - 1
+    val = np.ascontiguousarray(val, dtype=np.float64)
+    b64 = val.view(np.uint64).astype(np.int64)
+    sign = (b64 >> 63) & 1
+    e_in = (b64 >> 52) & 0x7FF
+    m_in = b64 & ((1 << 52) - 1)
+    is_nan = np.isnan(val)
+    is_inf = np.isinf(val)
+    # significand with implicit bit; float64 subnormals have no implicit bit
+    denorm_in = e_in == 0
+    sig = np.where(denorm_in, m_in, m_in | (1 << 52))
+    unbiased = np.where(denorm_in, -1022, e_in - 1023)
+    # E <= 0 lands in the target's subnormal range and needs extra right-shifts
+    E = unbiased + bias
+    k = np.clip((52 - mw) + np.maximum(0, 1 - E), 0, 62)
+    keep = sig >> k
+    rem = sig & ((np.int64(1) << k) - 1)
+    if rounding_mode is None or rounding_mode == _ir.ROUNDING_MODE.RTNE:
+        half = np.where(k > 0, np.int64(1) << np.maximum(k - 1, 0), np.int64(0))
+        round_up = ((rem > half) | ((rem == half) & ((keep & 1) == 1))) & (k > 0)
+        keep = keep + round_up
+    elif rounding_mode == _ir.ROUNDING_MODE.RTZ:
+        pass
+    else:
+        raise ValueError(f"unsupported rounding mode {rounding_mode}")
+    # (E << mw) + keep - 2^mw lets a mantissa carry overflow into the exponent;
+    # in the subnormal case keep == 2^mw naturally becomes the minimum normal
+    expmant = np.where(E >= 1, (E << mw) + keep - (1 << mw), keep)
+    if kind == "ieee":
+        inf_code = e_max << mw
+        max_finite = inf_code - 1
+        if rounding_mode == _ir.ROUNDING_MODE.RTZ:
+            expmant = np.minimum(expmant, max_finite)  # RTZ never rounds to inf
+        else:
+            expmant = np.where(expmant >= inf_code, inf_code, expmant)
+        result = (sign << (mw + ew)) | expmant
+        result = np.where(is_inf, (sign << (mw + ew)) | inf_code, result)
+        result = np.where(is_nan, (sign << (mw + ew)) | inf_code | (1 << (mw - 1)), result)
+    elif kind == "fn":
+        max_finite = (e_max << mw) | ((1 << mw) - 2)
+        expmant = np.minimum(expmant, max_finite)  # satfinite (also maps inf)
+        result = (sign << (mw + ew)) | expmant
+        result = np.where(is_nan, (e_max << mw) | ((1 << mw) - 1), result)
+    elif kind == "fnuz":
+        max_finite = (e_max << mw) | ((1 << mw) - 1)
+        expmant = np.minimum(expmant, max_finite)
+        # fnuz has no -0 (the sign-only pattern is the NaN code): anything
+        # that rounds to zero encodes as +0
+        result = np.where(expmant == 0, np.int64(0), (sign << (mw + ew)) | expmant)
+        result = np.where(is_nan, np.int64(1) << (mw + ew), result)
+    else:  # "none" (fp8e4b15): no inf/nan representation, saturate
+        max_finite = (e_max << mw) | ((1 << mw) - 1)
+        expmant = np.minimum(expmant, max_finite)
+        result = (sign << (mw + ew)) | expmant
+    out_uint_dtype = getattr(np, f"uint{dtype.primitive_bitwidth}")
+    return result.astype(out_uint_dtype)
+
+
 def _convert_float(input, input_dtype, output_dtype, rounding_mode):
     input_uint_dtype = getattr(np, f"uint{input_dtype.primitive_bitwidth}")
-    output_unint_dtype = getattr(np, f"uint{output_dtype.primitive_bitwidth}")
-    input_bin = np.frombuffer(input.tobytes(), dtype=input_uint_dtype)
-    sign = (input_bin >> (input_dtype.primitive_bitwidth - 1)) & 0x01
-    input_exponent_width = input_dtype.primitive_bitwidth - input_dtype.fp_mantissa_width - 1
-    output_exponent_width = output_dtype.primitive_bitwidth - output_dtype.fp_mantissa_width - 1
-    significand = input_bin & ((1 << input_dtype.fp_mantissa_width) - 1)
-    bias_input = input_dtype.exponent_bias
-    bias_output = output_dtype.exponent_bias
-    exponent = ((input_bin >> input_dtype.fp_mantissa_width) & ((1 << input_exponent_width) - 1)).astype(np.int32)
-    subnormal_index = exponent == 0
-    if np.any(subnormal_index):
-        # Credit to Phil: phil@openai.com
-        # subnormal repr: ((-1.0)**sign) * (2.0**(1 - exp_bias)) * (2^(m0) + 2^(m1) + ... + 2^(mn))
-        # where m0, m1, ..., mn are the 1-bit of the mantissa
-        # convert it to normal repr: ((-1.0)**sign) * (2.0**(1 + m0 - exp_bias)) * (1 + 2^(m1 - m0) + ... + 2^(mn - m0))
-        bit_pos = np.zeros_like(input_bin, dtype=np.int32)
-        # Find the most significant bit of the mantissa in the significand
-        for i in range(input_dtype.fp_mantissa_width):
-            bit_index = ((significand >> i) & 0x01)
-            # pos should be >= 1
-            bit_pos[bit_index == 1] = input_dtype.fp_mantissa_width - i
-        zero_significand_index = significand == 0
-        exponent[subnormal_index] = 1 - bit_pos[subnormal_index]
-        # 0 significand and subnormal should be treated as 0
-        exponent[zero_significand_index & subnormal_index] = bias_input - bias_output
-        significand[subnormal_index] = (significand[subnormal_index] << bit_pos[subnormal_index]) & (
-            (1 << input_dtype.fp_mantissa_width) - 1)
-    # Prevent overflow and underflow
-    exponent_output = np.maximum(0, np.minimum((exponent - bias_input + bias_output), (1 << output_exponent_width) - 1))
-    exponent_output = exponent_output.astype(output_unint_dtype)
-    sign_output = sign.astype(output_unint_dtype)
-    if input_dtype.primitive_bitwidth > output_dtype.primitive_bitwidth:  # Downcast
-        significand_output = (significand >> (input_dtype.fp_mantissa_width - output_dtype.fp_mantissa_width)) & (
-            (1 << output_dtype.fp_mantissa_width) - 1)
-        if rounding_mode == _ir.ROUNDING_MODE.RTNE:  # Round to nearst even
-            # find the cut-off bit
-            cut_off = significand & (1 << (input_dtype.fp_mantissa_width - output_dtype.fp_mantissa_width - 1))
-            significand_output = significand_output + (cut_off > 0)
-        significand_output = significand_output.astype(output_unint_dtype)
-    else:  # Upcast
-        significand_output = (significand.astype(output_unint_dtype) <<
-                              (output_dtype.fp_mantissa_width - input_dtype.fp_mantissa_width)) & (
-                                  (1 << output_dtype.fp_mantissa_width) - 1)
-    subnormal_index = exponent_output == 0
-    if np.any(subnormal_index):  # underflow
-        # normal repr: ((-1.0)**sign) * (2.0**(exp - exp_bias_input)) * (1 + 2^(m0) + 2^(m1) + ... + 2^(mn))
-        # where m0, m1, ..., mn are the 1-bit of the mantissa
-        # shift = (1 - exp_bias_output) - (exp - exp_bias_input)
-        # convert it to subnormal repr: ((-1.0)**sign) * (2.0**(1 - exp_bias_output)) * (2^(-shift) + 2^(m0 - shift) + 2^(m1 - shift) + ... + 2^(mn - shift))
-        exponent = ((input_bin >> input_dtype.fp_mantissa_width) & ((1 << input_exponent_width) - 1)).astype(np.int32)
-        non_zero_exponent_index = exponent != 0
-        # If the original exponent is not zero, we still need to shift the significand and consider the 1.0 part in mantissa
-        subnormal_index = subnormal_index & non_zero_exponent_index
-        shift = np.zeros_like(input_bin, dtype=np.int32)
-        shift[subnormal_index] = (1 - bias_output) - (exponent[subnormal_index] - bias_input)
-        significand_output[subnormal_index] = (significand_output[subnormal_index] >> shift[subnormal_index]) | (
-            1 << (output_dtype.fp_mantissa_width - shift[subnormal_index]))
-    output = (sign_output << (output_dtype.primitive_bitwidth - 1)) | (
-        exponent_output << output_dtype.fp_mantissa_width) | significand_output
+    input_bits = np.frombuffer(input.tobytes(), dtype=input_uint_dtype)
+    val = _decode_float_to_fp64(input_bits, input_dtype)
+    output = _encode_fp64_to_float(val, output_dtype, rounding_mode)
     return output.reshape(input.shape)
 
 
@@ -459,7 +515,7 @@ class InterpreterBuilder:
         return TensorHandle(np.array([self.grid_dim[axis]], dtype=np.int32), tl.int32)
 
     # memory ops
-    def create_load(self, ptr, _0, _1, is_volatile):
+    def create_load(self, ptr, _0, _1, is_volatile, flagtree_hints=None):
         mask = TensorHandle(np.ones_like(ptr.data, dtype=bool), tl.int1)
         other = None
         return self.create_masked_load(ptr, mask, other, _0, _1, is_volatile)
@@ -468,7 +524,7 @@ class InterpreterBuilder:
         mask = TensorHandle(np.ones_like(ptr.data, dtype=bool), tl.int1)
         return self.create_masked_store(ptr, val, mask, None, None)
 
-    def create_masked_load(self, ptrs, mask, other, cache_modifier, eviction_policy, is_volatile):
+    def create_masked_load(self, ptrs, mask, other, cache_modifier, eviction_policy, is_volatile, flagtree_hints=None):
         dtype_tt = ptrs.get_element_ty()
         dtype_np = _get_np_dtype(dtype_tt)
         if other is None:

--- a/python/tutorials/precision/01-fp8.py
+++ b/python/tutorials/precision/01-fp8.py
@@ -1,0 +1,163 @@
+"""
+FP8 (E4M3FN)
+============
+
+In this tutorial, you will use the FP8 support of FlagTree.
+
+In doing so, you will learn about:
+
+* Querying per-product capability declarations and branching on them.
+
+* Casting to and from FP8 with satfinite saturation and strict RTNE/RTZ rounding,
+  which works even on products without native FP8 cvt instructions (software cast).
+
+* FP8 matmul: native where declared, otherwise a preserved emulation path that
+  warns at compile time and is declared native=false.
+
+"""
+
+# %%
+# Capability Declarations
+# -----------------------
+# FP8 support differs per product, so backends declare what they actually
+# provide: `supported_fp8_dtypes` for storage (dual-whitelist backends refine
+# it with `supported_fp8_storage_dtypes`), `supported_fp8_cast_dtypes`
+# for numerical casts (`custom_cast_fp8_dtypes` marks the ones lowered in
+# software), and `async_copy_dtypes` / `descriptor_dtypes` for data movement.
+# The declarations ship with every compiled kernel (`h.metadata`), so programs
+# can branch on them instead of guessing.
+
+import warnings
+
+import torch
+
+import triton
+import triton.language as tl
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+TARGET = triton.runtime.driver.active.get_current_target()
+
+
+def backend_options():
+    from triton.compiler import make_backend
+    return make_backend(TARGET).parse_options({})
+
+
+opts = backend_options()
+FP8_STORAGE = getattr(opts, "supported_fp8_storage_dtypes", getattr(opts, "supported_fp8_dtypes", ()))
+FP8_CAST = getattr(opts, "supported_fp8_cast_dtypes", FP8_STORAGE)
+FP8_SW_CAST = getattr(opts, "custom_cast_fp8_dtypes", ())
+
+print(f"target:            {TARGET.backend} / {TARGET.arch}")
+print(f"fp8 storage:       {FP8_STORAGE}")
+print(f"fp8 cast:          {FP8_CAST}")
+print(f"fp8 software cast: {FP8_SW_CAST}")
+
+HAS_E4M3FN = "fp8e4nv" in FP8_CAST
+
+# %%
+# FP8 Quantization Is Just a Cast
+# -------------------------------
+# E4M3FN downcasts saturate to +-448 (satfinite) and round with RTNE by default
+# (RTZ is also available via `fp_downcast_rounding`). NaN maps to the NaN code.
+# FP8 values travel as plain bytes: bitcast to uint8 for storage, bitcast back
+# to reinterpret. There is no implicit FP8 <-> integer numerical conversion.
+
+
+@triton.jit
+def fp8_quant_kernel(x_ptr, q_ptr, scale, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    x = tl.load(x_ptr + offs, mask=mask)
+    q = (x / scale).to(tl.float8e4nv)  # satfinite + RTNE built in
+    tl.store(q_ptr + offs, q.to(tl.uint8, bitcast=True), mask=mask)
+
+
+@triton.jit
+def fp8_dequant_kernel(q_ptr, y_ptr, scale, N, BLOCK: tl.constexpr):
+    offs = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < N
+    bits = tl.load(q_ptr + offs, mask=mask)
+    y = bits.to(tl.float8e4nv, bitcast=True).to(tl.float32) * scale
+    tl.store(y_ptr + offs, y, mask=mask)
+
+
+def demo_fp8_quantization():
+    n, block, scale = 4096, 1024, 0.05
+    x = torch.randn(n, device=DEVICE) * 10
+    q = torch.empty(n, dtype=torch.uint8, device=DEVICE)
+    y = torch.empty(n, dtype=torch.float32, device=DEVICE)
+    grid = (triton.cdiv(n, block), )
+    fp8_quant_kernel[grid](x, q, scale, n, BLOCK=block)
+    fp8_dequant_kernel[grid](q, y, scale, n, BLOCK=block)
+    # torch's CPU float8 conversion is the reference for in-range values; on
+    # overflow the two differ by design: torch yields NaN, Triton saturates
+    xs = x.cpu() / scale
+    ref_bits = xs.to(torch.float8_e4m3fn).view(torch.uint8)
+    in_range = xs.abs() <= 448.0
+    assert torch.equal(q.cpu()[in_range], ref_bits[in_range])
+    err = (y - x)[in_range.to(DEVICE)].abs().max().item()
+    print(f"fp8 quant/dequant: bit-exact vs torch reference in range, max roundtrip err {err:.4f}")
+
+    # satfinite: overflow clamps to +-448 instead of mapping to the NaN code
+    big = torch.tensor([1e6, -1e6], device=DEVICE)
+    qb = torch.empty(2, dtype=torch.uint8, device=DEVICE)
+    yb = torch.empty(2, dtype=torch.float32, device=DEVICE)
+    fp8_quant_kernel[(1, )](big, qb, 1.0, 2, BLOCK=2)
+    fp8_dequant_kernel[(1, )](qb, yb, 1.0, 2, BLOCK=2)
+    print(f"satfinite: 1e6 -> {yb[0].item()}, -1e6 -> {yb[1].item()}")
+
+
+if HAS_E4M3FN:
+    demo_fp8_quantization()
+else:
+    print("E4M3FN cast is not declared on this product -- skipping (as declared)")
+
+# %%
+# FP8 Matmul and the Emulation Warning
+# ------------------------------------
+# `tl.dot` legality is resolved by the backend's capability rules. Products with
+# native FP8 matrix cores run it natively; products that keep the legacy
+# FP16-promotion path still execute it, but emit a compile-time warning and
+# declare native=false, so silent degradation cannot happen. The warning shows
+# up when the kernel is actually compiled (a warm cache skips compilation).
+
+
+@triton.jit
+def fp8_matmul_kernel(a_ptr, b_ptr, c_ptr, M, N, K, BM: tl.constexpr, BN: tl.constexpr, BK: tl.constexpr):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BM + tl.arange(0, BM)
+    offs_n = pid_n * BN + tl.arange(0, BN)
+    acc = tl.zeros((BM, BN), dtype=tl.float32)
+    for k0 in range(0, K, BK):
+        offs_k = k0 + tl.arange(0, BK)
+        a = tl.load(a_ptr + offs_m[:, None] * K + offs_k[None, :])  # fp8 typed pointer
+        b = tl.load(b_ptr + offs_k[:, None] * N + offs_n[None, :])
+        acc = tl.dot(a, b, acc=acc)
+    tl.store(c_ptr + offs_m[:, None] * N + offs_n[None, :], acc)
+
+
+def demo_fp8_matmul():
+    M = N = K = 256
+    bm, bn, bk = 64, 64, 64
+    a8 = (torch.randn(M, K) * 0.5).to(torch.float8_e4m3fn).view(torch.uint8).to(DEVICE)
+    b8 = (torch.randn(K, N) * 0.5).to(torch.float8_e4m3fn).view(torch.uint8).to(DEVICE)
+    c = torch.empty((M, N), dtype=torch.float32, device=DEVICE)
+    grid = (M // bm, N // bn)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fp8_matmul_kernel[grid](triton.reinterpret(a8, tl.float8e4nv), triton.reinterpret(b8, tl.float8e4nv), c, M, N,
+                                K, BM=bm, BN=bn, BK=bk)
+    for msg in dict.fromkeys(str(w.message) for w in caught):
+        print(f"compile-time warning: {msg}")
+    a_ref = a8.cpu().view(torch.float8_e4m3fn).to(torch.float32)
+    b_ref = b8.cpu().view(torch.float8_e4m3fn).to(torch.float32)
+    torch.testing.assert_close(c.cpu(), a_ref @ b_ref, rtol=1e-4, atol=1e-2)
+    print("fp8 matmul: numerics match the upcast reference")
+
+
+if HAS_E4M3FN:
+    demo_fp8_matmul()
+else:
+    print("fp8 matmul is not available on this product -- skipping (as declared)")

--- a/python/tutorials/precision/02-fp4.py
+++ b/python/tutorials/precision/02-fp4.py
@@ -1,0 +1,106 @@
+"""
+FP4 (E2M1)
+==========
+
+In this tutorial, you will use the FP4 support of FlagTree.
+
+In doing so, you will learn about:
+
+* The packed-uint8 container convention: FP4 has no dtype of its own.
+
+* The in-kernel decode recipe: split the bit fields, rebase the exponent,
+  bitcast to fp16 -- all 16 patterns are exact.
+
+* `tl.dot_scaled` with the "e2m1" format tag as the only matrix entry point.
+
+"""
+
+# %%
+# Packed Containers
+# -----------------
+# FP4 has no dtype of its own: a 4-bit itemsize would break pointer arithmetic
+# and layout analysis. Instead, two E2M1 values live in each uint8 (low nibble
+# first) and the container moves through ordinary byte paths without unpacking.
+# Decoding is a three-step bit recipe: split the fields, rebase the exponent
+# (bias 1 -> 15), and bitcast to fp16. All 16 patterns are exact.
+
+import warnings
+
+import torch
+
+import triton
+import triton.language as tl
+
+DEVICE = triton.runtime.driver.active.get_active_torch_device()
+
+E2M1_VALUES = torch.tensor([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0])
+
+
+def decode_e2m1(nibbles):
+    sign = torch.where(nibbles >> 3 != 0, -1.0, 1.0)
+    return sign * E2M1_VALUES[(nibbles & 0x7).long()]
+
+
+@triton.jit
+def fp4_decode_kernel(packed_ptr, out_ptr, BLOCK: tl.constexpr):
+    offs = tl.arange(0, BLOCK)
+    packed = tl.load(packed_ptr + offs)
+    nib = tl.interleave(packed & 0xF, packed >> 4).to(tl.uint16)  # low nibble first
+    s, e, m = nib >> 3, (nib >> 1) & 0x3, nib & 0x1
+    bits = (s << 15) | tl.where(e == 0, m * 0x3800, ((e + 14) << 10) | (m << 9))
+    tl.store(out_ptr + tl.arange(0, 2 * BLOCK), bits.to(tl.float16, bitcast=True))
+
+
+def demo_fp4_decode():
+    packed = torch.arange(256, dtype=torch.uint8).to(DEVICE)
+    out = torch.empty(512, dtype=torch.float16, device=DEVICE)
+    fp4_decode_kernel[(1, )](packed, out, BLOCK=256)
+    nibbles = torch.stack([packed.cpu() & 0xF, packed.cpu() >> 4], dim=-1).reshape(-1)
+    assert torch.equal(out.cpu().float(), decode_e2m1(nibbles))
+    print("fp4 decode: all 256 byte patterns (512 nibbles) match the E2M1 table")
+
+
+demo_fp4_decode()
+
+# %%
+# FP4 Matmul via `tl.dot_scaled`
+# ------------------------------
+# A packed container fed to plain `tl.dot` is just a uint8 tensor and is
+# rejected by the integer rules. The only matrix entry point is
+# `tl.dot_scaled`, where the "e2m1" format tag gives the container its
+# semantics. Scales use the e8m0 format (127 encodes 1.0). Products without a
+# native scaled-MMA path decompose to a promoted dot and warn at compile time,
+# declared native=false, so silent degradation cannot happen.
+
+
+@triton.jit
+def fp4_matmul_kernel(a_ptr, as_ptr, b_ptr, c_ptr, BM: tl.constexpr, BN: tl.constexpr, BK: tl.constexpr):
+    offs_m = tl.arange(0, BM)
+    offs_n = tl.arange(0, BN)
+    offs_k = tl.arange(0, BK)
+    a = tl.load(a_ptr + offs_m[:, None] * (BK // 2) + tl.arange(0, BK // 2)[None, :])  # packed uint8
+    b = tl.load(b_ptr + offs_k[:, None] * BN + offs_n[None, :])  # bf16
+    a_scale = tl.load(as_ptr + offs_m[:, None] * (BK // 32) + tl.arange(0, BK // 32)[None, :])
+    c = tl.dot_scaled(a, a_scale, "e2m1", b, None, "bf16")
+    tl.store(c_ptr + offs_m[:, None] * BN + offs_n[None, :], c)
+
+
+def demo_fp4_matmul():
+    bm = bn = bk = 64
+    a_packed = torch.randint(0, 256, (bm, bk // 2), dtype=torch.uint8, device=DEVICE)
+    b = (torch.rand(bk, bn, device=DEVICE) * 4 - 2).to(torch.bfloat16)
+    ones = torch.full((bm, bk // 32), 127, dtype=torch.uint8, device=DEVICE)  # e8m0 for 1.0
+    c = torch.empty((bm, bn), dtype=torch.float32, device=DEVICE)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        fp4_matmul_kernel[(1, )](a_packed, ones, b, c, BM=bm, BN=bn, BK=bk)
+    for msg in dict.fromkeys(str(w.message) for w in caught):
+        print(f"compile-time warning: {msg}")
+    nibbles = torch.stack([a_packed.cpu() & 0xF, a_packed.cpu() >> 4], dim=-1).reshape(bm, bk)
+    a_ref = decode_e2m1(nibbles)
+    ref = a_ref @ b.cpu().to(torch.float32)
+    torch.testing.assert_close(c.cpu(), ref, rtol=2e-2, atol=1e-1)
+    print("fp4 dot_scaled: numerics match the decode-table reference")
+
+
+demo_fp4_matmul()

--- a/third_party/mthreads/backend/compiler.py
+++ b/third_party/mthreads/backend/compiler.py
@@ -1,4 +1,4 @@
-from triton.backends.compiler import BaseBackend, GPUTarget, Language
+from triton.backends.compiler import BaseBackend, DotCap, DotSupport, GPUTarget, Language
 from triton._C.libtriton import ir, passes, mthreads
 from triton import knobs
 from triton.runtime.errors import OutOfResources
@@ -28,6 +28,77 @@ def min_dot_size(target: GPUTarget):
         return (1, 1, 1)
 
     return check_dot_compatibility
+
+
+# Whole-byte dtypes covered by the inherited async-copy/descriptor movement
+# paths; the fp8 portion follows the per-capability storage whitelist
+_MOVEMENT_DTYPES = ("int8", "uint8", "int16", "uint16", "int32", "uint32", "int64", "uint64", "fp16", "bf16", "fp32",
+                    "fp64")
+
+# fp8e4b15/fp8e4b8/fp8e5b16 are storage-only dtypes: the dot whitelist keeps
+# them out of tl.dot, so resolve_dot only ever sees the two OCP formats
+_FP8_DOT_DTYPES = ("fp8e4nv", "fp8e5")
+_NATIVE_SAME_TYPE_DOT_DTYPES = ("fp16", "bf16", "fp32", "fp64")
+
+# PH1 8-bit operand instruction tiles (WMMA m/n/k; the SQMMA K values {32, 64,
+# 128} are divisibility-implied). A shape that divides no tile cannot use the
+# matrix units and falls back to the FMA software path.
+_FP8_INSTR_TILES = ((8, 16, 16), (16, 8, 16), (16, 16, 16), (16, 16, 32), (16, 16, 64))
+
+
+def _product_name(capability: int) -> str:
+    return "MThreads S5000 (cap31)" if capability == 31 else f"MThreads (cap{capability})"
+
+
+def _hits_fp8_instr_tile(M: int, N: int, K: int) -> bool:
+    return any(M % m == 0 and N % n == 0 and K % k == 0 for m, n, k in _FP8_INSTR_TILES)
+
+
+def _make_resolve_dot(capability: int):
+    """resolve_dot rule: INT8xINT8->INT32 is native; same-type FP8 dot with an
+    fp32 accumulator is native from cap31 when the shape hits an instruction
+    tile; mixed fp8 and instruction-shape misses keep the preserved FMA
+    fallback (EMULATED); every other combination is a compile-time error."""
+    product = _product_name(capability)
+
+    def resolve_dot(a_dtype, b_dtype, acc_dtype, M, N, K):
+        if a_dtype == "int8" and b_dtype == "int8":
+            return DotCap(DotSupport.NATIVE)
+        if a_dtype in _FP8_DOT_DTYPES and b_dtype in _FP8_DOT_DTYPES:
+            if capability >= 31 and a_dtype == b_dtype and acc_dtype == "fp32" and _hits_fp8_instr_tile(M, N, K):
+                return DotCap(DotSupport.NATIVE)
+            if capability < 31:
+                reason = "no native fp8 matrix instructions on this capability"
+            elif a_dtype != b_dtype:
+                reason = "mixed fp8 operand dtypes"
+            elif acc_dtype != "fp32":
+                reason = f"{acc_dtype} accumulator (accelerated fp8 dot requires fp32)"
+            else:
+                reason = f"shape {M}x{N}x{K} misses the 8-bit instruction tiles"
+            return DotCap(
+                DotSupport.EMULATED, diag=f"FP8 dot on {product} is not native ({reason}): "
+                "emulated via the FMA software path (native=false)")
+        if a_dtype == b_dtype and a_dtype in _NATIVE_SAME_TYPE_DOT_DTYPES:
+            return DotCap(DotSupport.NATIVE)
+        return DotCap(
+            DotSupport.UNSUPPORTED, diag=f"tl.dot: {a_dtype} x {b_dtype} is not supported on {product}; "
+            "native alternatives: int8 / fp16 / bf16 / fp32 / fp64 dot")
+
+    return resolve_dot
+
+
+def _make_resolve_dot_scaled(capability: int):
+    """resolve_dot_scaled rule: no MUSA capability has a native scaled-MMA
+    path; every format combination decomposes to a promoted fp16/bf16 dot
+    and is declared EMULATED with a compile-time warning."""
+    product = _product_name(capability)
+
+    def resolve_dot_scaled(lhs_format, rhs_format):
+        return DotCap(
+            DotSupport.EMULATED, diag=f"tl.dot_scaled ({lhs_format} x {rhs_format}) on {product} is not native: "
+            "decomposed to a promoted fp16/bf16 dot (native=false)")
+
+    return resolve_dot_scaled
 
 
 def _module_text(mod) -> str:
@@ -658,7 +729,10 @@ class MUSAOptions:
     launch_cooperative_grid: bool = False
     supported_fp8_dtypes: Tuple[str, ...] = ("fp8e5", )
     supported_fp8_storage_dtypes: Tuple[str, ...] = ("fp8e5", )
-    custom_fp8_dtypes: Tuple[str, ...] = ()
+    supported_fp8_cast_dtypes: Tuple[str, ...] = ()
+    custom_cast_fp8_dtypes: Tuple[str, ...] = ()
+    async_copy_dtypes: Tuple[str, ...] = ()
+    descriptor_dtypes: Tuple[str, ...] = ()
     deprecated_fp8_dot_operand_dtypes: Tuple[str, ...] = ()
     default_dot_input_precision: str = "ieee"
     allowed_dot_input_precisions: Tuple[str, ...] = ("ieee", "tf32", "tf32x3", "bf16x3", "bf16x6")
@@ -844,15 +918,23 @@ class MUSABackend(BaseBackend):
                 supported_fp8_dtypes.add("fp8e4nv")
             args["supported_fp8_dtypes"] = tuple(sorted(supported_fp8_dtypes))
         if "supported_fp8_storage_dtypes" not in opts:
-            supported_fp8_storage_dtypes = set(args.get("supported_fp8_dtypes", ()))
+            supported_fp8_storage_dtypes = set(opts.get("supported_fp8_dtypes") or args.get("supported_fp8_dtypes", ()))
             if capability >= 31:
                 supported_fp8_storage_dtypes.update({"fp8e4b15", "fp8e4b8", "fp8e5b16"})
             args["supported_fp8_storage_dtypes"] = tuple(sorted(supported_fp8_storage_dtypes))
-        if "custom_fp8_dtypes" not in opts:
-            custom_fp8_dtypes = set()
+        storage_dtypes = opts.get("supported_fp8_storage_dtypes") or args.get("supported_fp8_storage_dtypes", ())
+        if "supported_fp8_cast_dtypes" not in opts:
+            # every storable fp8 dtype has a hardware or software cast lowering
+            args["supported_fp8_cast_dtypes"] = tuple(storage_dtypes)
+        if "custom_cast_fp8_dtypes" not in opts:
+            custom_cast_fp8_dtypes = set()
             if capability >= 31:
-                custom_fp8_dtypes.update({"fp8e4b15", "fp8e4b8", "fp8e5b16"})
-            args["custom_fp8_dtypes"] = tuple(sorted(custom_fp8_dtypes))
+                custom_cast_fp8_dtypes.update({"fp8e4b15", "fp8e4b8", "fp8e5b16"})
+            args["custom_cast_fp8_dtypes"] = tuple(sorted(custom_cast_fp8_dtypes))
+        if "async_copy_dtypes" not in opts:
+            args["async_copy_dtypes"] = tuple(sorted(set(_MOVEMENT_DTYPES) | set(storage_dtypes)))
+        if "descriptor_dtypes" not in opts:
+            args["descriptor_dtypes"] = opts.get("async_copy_dtypes") or args.get("async_copy_dtypes", ())
         if "deprecated_fp8_dot_operand_dtypes" not in opts:
             args["deprecated_fp8_dot_operand_dtypes"] = ()
         if "llc_path" not in opts:
@@ -887,9 +969,12 @@ class MUSABackend(BaseBackend):
     def get_codegen_implementation(self, options):
         from triton.language.extra.musa import utils as musa_utils
 
+        capability = _capability_from_arch(options.arch)
         return {
             "convert_custom_types": musa_utils.convert_custom_float8,
             "min_dot_size": min_dot_size(self.target),
+            "resolve_dot": _make_resolve_dot(capability),
+            "resolve_dot_scaled": _make_resolve_dot_scaled(capability),
         }
 
     def get_module_map(self) -> Dict[str, object]:
@@ -1035,7 +1120,7 @@ class MUSABackend(BaseBackend):
         mthreads.passes.ttgpuir.add_allocate_shared_memory(pm, capability)
         passes.ttgpuir.add_allocate_global_scratch_memory(pm)
         mthreads.passes.ttgpuir.add_mtgpu_to_llvm(pm, capability)
-        mthreads.passes.ttgpuir.add_to_llvmir(pm, capability)
+        mthreads.passes.ttgpuir.add_to_llvmir(pm, capability, options.enable_fp8_burst2)
         if has_static_ws:
             # The retained operation still owns the producer and consumer
             # regions here.  Lower their hardware barriers once, then emit the

--- a/third_party/mthreads/lib/Dialect/TritonGPU/Transforms/Utility.cpp
+++ b/third_party/mthreads/lib/Dialect/TritonGPU/Transforms/Utility.cpp
@@ -1739,6 +1739,21 @@ void replaceUsesAndPropagateType(
       auto shape = reshape.getType().getShape();
       newVal =
           ttg::MemDescReshapeOp::create(builder, reshape.getLoc(), val, shape);
+    } else if (auto reinterpret = dyn_cast<ttg::MemDescReinterpretOp>(user)) {
+      // Same-shape element-type reinterpretation (fp8 operands staged through
+      // a same-width bit container): retype the propagated value, keeping its
+      // layout, mutability and alloc shape.
+      auto oldSrcType = cast<ttg::MemDescType>(reinterpret.getSrc().getType());
+      ttg::MemDescType oldType = reinterpret.getType();
+      auto valType = cast<ttg::MemDescType>(val.getType());
+      if (oldSrcType.getShape() == oldType.getShape()) {
+        Type newDstType = ttg::MemDescType::get(
+            valType.getShape(), oldType.getElementType(), valType.getEncoding(),
+            valType.getMemorySpace(), valType.getMutableMemory(),
+            valType.getAllocShape());
+        newVal = ttg::MemDescReinterpretOp::create(
+            builder, reinterpret.getLoc(), newDstType, val);
+      }
     }
     assert(newVal && "unhandled memdesc view");
     newVal.getDefiningOp()->setAttrs(user->getAttrs());

--- a/third_party/mthreads/musa/include/TritonMUSAGPUToLLVM/Passes.h
+++ b/third_party/mthreads/musa/include/TritonMUSAGPUToLLVM/Passes.h
@@ -25,6 +25,9 @@ std::unique_ptr<OperationPass<ModuleOp>> createConvertTritonMUSAGPUToLLVMPass();
 std::unique_ptr<OperationPass<ModuleOp>>
 createConvertTritonMUSAGPUToLLVMPass(int32_t computeCapability);
 std::unique_ptr<OperationPass<ModuleOp>>
+createConvertTritonMUSAGPUToLLVMPass(int32_t computeCapability,
+                                     bool enableFp8Burst2);
+std::unique_ptr<OperationPass<ModuleOp>>
 createAllocateMUSASharedMemoryPass(int32_t computeCapability);
 
 #define GEN_PASS_REGISTRATION

--- a/third_party/mthreads/musa/include/TritonMUSAGPUToLLVM/Passes.td
+++ b/third_party/mthreads/musa/include/TritonMUSAGPUToLLVM/Passes.td
@@ -19,6 +19,9 @@ def ConvertTritonMUSAGPUToLLVM : Pass<"convert-triton-musagpu-to-llvm", "mlir::M
         Option<"computeCapability", "compute-capability",
                "int32_t", /*default*/"31",
                "device compute capability">,
+        Option<"enableFp8Burst2", "enable-fp8-burst2",
+               "bool", /*default*/"false",
+               "use burst2 (vector) fp8 conversion intrinsics">,
     ];
 }
 

--- a/third_party/mthreads/musa/lib/Dialect/MUSA/IR/Dialect.cpp
+++ b/third_party/mthreads/musa/lib/Dialect/MUSA/IR/Dialect.cpp
@@ -396,6 +396,8 @@ LogicalResult WmmaDotOp::inferReturnTypes(
 LogicalResult WmmaDotOp::verify() {
   auto aTy = cast<RankedTensorType>(getA().getType());
   auto bTy = cast<RankedTensorType>(getB().getType());
+  if (aTy.getElementType() != bTy.getElementType())
+    return emitError("WMMA operands A and B must use the same element type");
   if (aTy.getElementType().getIntOrFloatBitWidth() !=
       bTy.getElementType().getIntOrFloatBitWidth())
     return emitError(

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUToLLVM/ElementwiseOpToLLVM.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUToLLVM/ElementwiseOpToLLVM.cpp
@@ -6,10 +6,8 @@
 #include "triton/Conversion/TritonGPUToLLVM/ElementwiseOpToLLVMBase.h"
 #include "triton/Conversion/TritonGPUToLLVM/PatternTritonGPUOpToLLVM.h"
 #include "triton/Dialect/Triton/IR/Dialect.h"
-#include "triton/Tools/Sys/GetEnv.hpp"
 
 #include <algorithm>
-#include <cctype>
 
 using namespace mlir;
 using namespace mlir::triton;
@@ -128,8 +126,10 @@ struct FpToFpOpConversion
 
   explicit FpToFpOpConversion(LLVMTypeConverter &typeConverter,
                               ModuleAxisInfoAnalysis &axisAnalysisPass,
+                              bool enableFp8Burst2,
                               PatternBenefit benefit = patternBenefitDefault)
-      : Base(typeConverter, axisAnalysisPass, benefit) {}
+      : Base(typeConverter, axisAnalysisPass, benefit),
+        enableFp8Burst2(enableFp8Burst2) {}
 
   struct Fp8ConversionDesc {
     StringRef funcName;
@@ -146,16 +146,6 @@ struct FpToFpOpConversion
     if (funcName == "__mt_tt_f16_to_e5m2")
       return "llvm.musa.f162e5m2.rn";
     return {};
-  }
-
-  static bool isFp8Burst2Enabled() {
-    std::string envValue =
-        mlir::triton::tools::getStrEnv("TRITON_MUSA_ENABLE_FP8_BURST2");
-    if (envValue.empty())
-      return false;
-    std::transform(envValue.begin(), envValue.end(), envValue.begin(),
-                   [](unsigned char c) { return std::tolower(c); });
-    return envValue == "1" || envValue == "true" || envValue == "on";
   }
 
   std::pair<StringRef, size_t>
@@ -413,7 +403,7 @@ struct FpToFpOpConversion
         }
       }
       auto [funcName, numElements] = getFp8ConversionFunc(
-          srcElemTy, dstElemTy, roundingMode, isFp8Burst2Enabled());
+          srcElemTy, dstElemTy, roundingMode, enableFp8Burst2);
       Type logicalSrcTy = typeConverter->convertType(srcElemTy);
       SmallVector<Value> inVals;
       for (unsigned i = 0; i < std::min(numElements, operands.size()); ++i) {
@@ -481,6 +471,9 @@ struct FpToFpOpConversion
 
     return {};
   }
+
+private:
+  bool enableFp8Burst2 = false;
 };
 
 template <typename OpType>
@@ -861,7 +854,8 @@ struct ExpOpConversionApprox
 void mlir::triton::MUSA::populateElementwiseOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
     ModuleAxisInfoAnalysis &axisInfoAnalysis, int /*computeCapability*/,
-    const TargetInfo &targetInfo, PatternBenefit benefit) {
+    bool enableFp8Burst2, const TargetInfo &targetInfo,
+    PatternBenefit benefit) {
   PatternBenefit priorityBenefit(benefit.getBenefit() + 1);
   patterns.add<FDivOpConversion>(typeConverter, axisInfoAnalysis,
                                  priorityBenefit);
@@ -883,7 +877,8 @@ void mlir::triton::MUSA::populateElementwiseOpToLLVMPatterns(
   patterns.add<TruncFOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<FPToSIOpConversion>(typeConverter, axisInfoAnalysis, benefit);
   patterns.add<SIToFPOpConversion>(typeConverter, axisInfoAnalysis, benefit);
-  patterns.add<FpToFpOpConversion>(typeConverter, axisInfoAnalysis, benefit);
+  patterns.add<FpToFpOpConversion>(typeConverter, axisInfoAnalysis,
+                                   enableFp8Burst2, benefit);
   patterns.add<PreciseSqrtOpConversion>(typeConverter, axisInfoAnalysis,
                                         priorityBenefit);
   patterns.add<PreciseDivOpConversion>(typeConverter, axisInfoAnalysis,

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUToLLVM/PatternTritonGPUOpToLLVM.h
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUToLLVM/PatternTritonGPUOpToLLVM.h
@@ -35,7 +35,7 @@ void populateFp4ToFpToLLVMPatterns(LLVMTypeConverter &typeConverter,
 void populateElementwiseOpToLLVMPatterns(
     LLVMTypeConverter &typeConverter, RewritePatternSet &patterns,
     ModuleAxisInfoAnalysis &axisInfoAnalysis, int computeCapability,
-    const TargetInfo &targetInfo, PatternBenefit benefit);
+    bool enableFp8Burst2, const TargetInfo &targetInfo, PatternBenefit benefit);
 
 void populateLoadStoreOpToLLVMPatterns(LLVMTypeConverter &typeConverter,
                                        const TargetInfo &targetInfo,

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -388,6 +388,8 @@ struct ConvertTritonMUSAGPUToLLVM
   ConvertTritonMUSAGPUToLLVM() = default;
   ConvertTritonMUSAGPUToLLVM(int32_t computeCapability)
       : ConvertTritonMUSAGPUToLLVMBase({computeCapability}) {}
+  ConvertTritonMUSAGPUToLLVM(int32_t computeCapability, bool enableFp8Burst2)
+      : ConvertTritonMUSAGPUToLLVMBase({computeCapability, enableFp8Burst2}) {}
 
   void runOnOperation() override {
     MLIRContext *context = &getContext();
@@ -455,7 +457,7 @@ struct ConvertTritonMUSAGPUToLLVM
                                                       benefit, targetInfo);
     mlir::triton::MUSA::populateElementwiseOpToLLVMPatterns(
         typeConverter, patterns, axisInfoAnalysis, computeCapability,
-        targetInfo, benefit);
+        enableFp8Burst2, targetInfo, benefit);
     mlir::triton::MUSA::populateLoadStoreOpToLLVMPatterns(
         typeConverter, targetInfo, computeCapability, patterns,
         axisInfoAnalysis, benefit);
@@ -577,6 +579,13 @@ createConvertTritonMUSAGPUToLLVMPass() {
 std::unique_ptr<OperationPass<ModuleOp>>
 createConvertTritonMUSAGPUToLLVMPass(int32_t computeCapability) {
   return std::make_unique<ConvertTritonMUSAGPUToLLVM>(computeCapability);
+}
+
+std::unique_ptr<OperationPass<ModuleOp>>
+createConvertTritonMUSAGPUToLLVMPass(int32_t computeCapability,
+                                     bool enableFp8Burst2) {
+  return std::make_unique<ConvertTritonMUSAGPUToLLVM>(computeCapability,
+                                                      enableFp8Burst2);
 }
 
 } // namespace mlir::triton

--- a/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/AccelerateMUSAMatmul.cpp
+++ b/third_party/mthreads/musa/lib/TritonMUSAGPUTransforms/AccelerateMUSAMatmul.cpp
@@ -999,9 +999,9 @@ static SmallVector<int64_t> getSqmmaPaddedAllocShape(RankedTensorType argType,
   return allocShape;
 }
 
-static Value getSharedMemorySqmmaOperand(const SqmmaSharedOperandPlan &plan,
-                                         PatternRewriter &rewriter, int opIdx,
-                                         ttg::MUSASqmmaEncodingAttr mmaEnc) {
+static Value stageSharedMemorySqmmaOperand(const SqmmaSharedOperandPlan &plan,
+                                           PatternRewriter &rewriter, int opIdx,
+                                           ttg::MUSASqmmaEncodingAttr mmaEnc) {
   OpBuilder::InsertionGuard g(rewriter);
   Value arg = plan.source;
   RankedTensorType argType = plan.type;
@@ -1107,6 +1107,36 @@ static Value getSharedMemorySqmmaOperand(const SqmmaSharedOperandPlan &plan,
       ttg::LocalAllocOp::create(rewriter, arg.getLoc(), memDescTy, arg);
   setSqmmaAttrs(localAlloc.getOperation());
   return localAlloc.getResult();
+}
+
+static Value getSharedMemorySqmmaOperand(const SqmmaSharedOperandPlan &plan,
+                                         PatternRewriter &rewriter, int opIdx,
+                                         ttg::MUSASqmmaEncodingAttr mmaEnc,
+                                         Type dotElemTy) {
+  Value memDesc = stageSharedMemorySqmmaOperand(plan, rewriter, opIdx, mmaEnc);
+  if (!memDesc)
+    return memDesc;
+  auto memDescTy = dyn_cast<ttg::MemDescType>(memDesc.getType());
+  if (!memDescTy || memDescTy.getElementType() == dotElemTy)
+    return memDesc;
+  // The staging plan walks through bitcasts, so operands fed from a same-width
+  // bit container (i8 loads bitcast to fp8) stage with the container type;
+  // retype the view to the element type the dot consumes.
+  if (memDescTy.getElementType().getIntOrFloatBitWidth() !=
+      dotElemTy.getIntOrFloatBitWidth())
+    return {};
+  auto retypedTy = ttg::MemDescType::get(
+      memDescTy.getShape(), dotElemTy, memDescTy.getEncoding(),
+      memDescTy.getMemorySpace(), memDescTy.getMutableMemory(),
+      memDescTy.getAllocShape());
+  OpBuilder::InsertionGuard g(rewriter);
+  rewriter.setInsertionPointAfterValue(memDesc);
+  Value retyped = ttg::MemDescReinterpretOp::create(rewriter, memDesc.getLoc(),
+                                                    retypedTy, memDesc);
+  if (auto elemBytes = getElementByteWidth(memDescTy.getElementType()))
+    triton::musa::setSqmmaAttrs(retyped.getDefiningOp(), opIdx, *elemBytes,
+                                plan.layout == triton::musa::SQMMALayout::row);
+  return retyped;
 }
 
 static std::optional<SelectedConfig>
@@ -1391,8 +1421,10 @@ public:
         planSharedMemorySqmmaOperand(dotOp.getB(), allowTransposeB);
     if (!sharedPlanA || !sharedPlanB)
       return failure();
-    Value newA = getSharedMemorySqmmaOperand(*sharedPlanA, rewriter, 0, mmaEnc);
-    Value newB = getSharedMemorySqmmaOperand(*sharedPlanB, rewriter, 1, mmaEnc);
+    Value newA =
+        getSharedMemorySqmmaOperand(*sharedPlanA, rewriter, 0, mmaEnc, aElemTy);
+    Value newB =
+        getSharedMemorySqmmaOperand(*sharedPlanB, rewriter, 1, mmaEnc, bElemTy);
     if (!newA || !newB)
       return failure();
 
@@ -1476,12 +1508,27 @@ public:
     auto aElemTy = problem->aElemType;
     auto bElemTy = problem->bElemType;
     bool allowTF32 = problem->allowTF32;
+    // Accelerated WMMA rejects fp16 accumulators/results (only the PH1
+    // f16 x f16 fp32-carrier path keeps an f16 result); bail out so these
+    // dots take the FMA promotion fallback.
+    if (oldRetType.getElementType().isF16() &&
+        !(*arch != triton::musa::MusaArch::QY2 && aElemTy.isF16() &&
+          bElemTy.isF16()))
+      return failure();
     auto config = selectWmmaConfig(*problem, wmmaTraits);
 #else
     auto aTy = cast<RankedTensorType>(dotOp.getA().getType());
     auto bTy = cast<RankedTensorType>(dotOp.getB().getType());
     auto aElemTy = aTy.getElementType();
     auto bElemTy = bTy.getElementType();
+
+    // Accelerated WMMA rejects fp16 accumulators/results (only the PH1
+    // f16 x f16 fp32-carrier path keeps an f16 result); bail out so these
+    // dots take the FMA promotion fallback.
+    if (oldRetType.getElementType().isF16() &&
+        !(*arch != triton::musa::MusaArch::QY2 && aElemTy.isF16() &&
+          bElemTy.isF16()))
+      return failure();
 
     if (!wmmaTraits.supportsNativeFp8Wmma &&
         (tt::type::isFloat8(aElemTy) || tt::type::isFloat8(bElemTy))) {
@@ -1758,8 +1805,10 @@ public:
                                             newRetType, acc);
     }
 
-    Value newA = getSharedMemorySqmmaOperand(*sharedPlanA, rewriter, 0, mmaEnc);
-    Value newB = getSharedMemorySqmmaOperand(*sharedPlanB, rewriter, 1, mmaEnc);
+    Value newA =
+        getSharedMemorySqmmaOperand(*sharedPlanA, rewriter, 0, mmaEnc, aElemTy);
+    Value newB =
+        getSharedMemorySqmmaOperand(*sharedPlanB, rewriter, 1, mmaEnc, bElemTy);
     if (!newA || !newB)
       return failure();
 

--- a/third_party/mthreads/spec/triton/backends/compiler.py
+++ b/third_party/mthreads/spec/triton/backends/compiler.py
@@ -1,7 +1,7 @@
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Union
+from typing import Dict, Optional, Union
 from types import ModuleType
 
 
@@ -12,6 +12,31 @@ class GPUTarget(object):
     # Target architecture, e.g., 90 (for cuda compute capability), gfx940 (for hip)
     arch: Union[int, str]
     warp_size: int
+
+
+class DotSupport(Enum):
+    """How a backend supports a dot dtype/format combination."""
+    NATIVE = "native"
+    EMULATED = "emulated"
+    UNSUPPORTED = "unsupported"
+
+
+@dataclass(frozen=True)
+class DotCap:
+    """Answer to a backend `resolve_dot(a_dtype, b_dtype, acc_dtype, M, N, K)` /
+    `resolve_dot_scaled(lhs_format, rhs_format)` codegen-function query: the
+    semantic layer rejects UNSUPPORTED combinations with `diag` as the error
+    message and emits `diag` as a compile-time warning for EMULATED ones."""
+    support: DotSupport
+    diag: Optional[str] = None
+
+    @property
+    def supported(self) -> bool:
+        return self.support is not DotSupport.UNSUPPORTED
+
+    @property
+    def native(self) -> bool:
+        return self.support is DotSupport.NATIVE
 
 
 class Language(Enum):

--- a/third_party/mthreads/spec/triton/language/semantic.py
+++ b/third_party/mthreads/spec/triton/language/semantic.py
@@ -826,17 +826,21 @@ class TritonSemantic(Generic[TensorTy]):
                                  "Source scalar type is " + str(src_sca_ty) + " and destination type is " +
                                  str(dst_sca_ty))
 
-        custom_fp8_dtypes = set(getattr(self.builder.options, "custom_fp8_dtypes", ()))
-        if self.builder.codegen_fns.get("convert_custom_types") is not None:
-            # Backwards compatibility for backends that only route fp8e4b15
-            # through custom casts and have not populated options.
-            if src_sca_ty.is_fp8e4b15() or dst_sca_ty.is_fp8e4b15():
-                custom_fp8_dtypes.add("fp8e4b15")
-
-        if str(src_sca_ty) in custom_fp8_dtypes or str(dst_sca_ty) in custom_fp8_dtypes:
-            assert self.builder.codegen_fns.get(
-                "convert_custom_types") is not None, "target doesn't provide conversion for this type."
-            return self.builder.codegen_fns["convert_custom_types"](input, dst_ty, fp_downcast_rounding, _semantic=self)
+        if src_sca_ty.is_fp8() or dst_sca_ty.is_fp8():
+            options = self.builder.options
+            cast_whitelist = getattr(options, "supported_fp8_cast_dtypes", None)
+            if cast_whitelist is not None and src_sca_ty.is_floating() and dst_sca_ty.is_floating():
+                for ty in (src_sca_ty, dst_sca_ty):
+                    if ty.is_fp8() and ty.name not in cast_whitelist:
+                        raise ValueError(f"cast involving type {ty} is not supported in this architecture. "
+                                         f"The supported fp8 cast dtypes are {cast_whitelist}")
+            # Backends declare fp8 dtypes with software casts under "custom_cast_fp8_dtypes";
+            # the default preserves the legacy fp8e4b15-only routing.
+            custom_cast_dtypes = getattr(options, "custom_cast_fp8_dtypes", ("fp8e4b15", ))
+            if src_sca_ty.name in custom_cast_dtypes or dst_sca_ty.name in custom_cast_dtypes:
+                custom_cast = self.builder.codegen_fns.get("convert_custom_types")
+                assert custom_cast is not None, "target doesn't provide conversion for this type."
+                return custom_cast(input, dst_ty, fp_downcast_rounding, _semantic=self)
         # Casting with customized floating types involved: fp8 <=> bf16, fp16, fp32, fp64
         # and non-default rounding modes for downcasting
         if (src_sca_ty.is_fp8() and dst_sca_ty.is_floating()) or \
@@ -1519,7 +1523,11 @@ class TritonSemantic(Generic[TensorTy]):
             max_num_imprecise_acc: int, out_dtype: tl.dtype) -> TensorTy:
         assert lhs.type.is_block() and rhs.type.is_block()
 
-        self._assert_dot_dtypes_valid(lhs.dtype, rhs.dtype)
+        # resolve_dot backends own the dtype rules (queried once shapes are known);
+        # the fp8 pairing and dot-whitelist hard-rejects stay in front regardless
+        resolve_dot = self.builder.codegen_fns.get("resolve_dot")
+        if lhs.dtype.is_fp8() or rhs.dtype.is_fp8() or resolve_dot is None:
+            self._assert_dot_dtypes_valid(lhs.dtype, rhs.dtype)
 
         if lhs.dtype.is_fp8e4b15() or rhs.dtype.is_fp8e4b15():
             if "fp8e4b15" in self.builder.options.deprecated_fp8_dot_operand_dtypes:
@@ -1554,6 +1562,15 @@ class TritonSemantic(Generic[TensorTy]):
             -2].value, f"First input shape ({lhs.shape}) and second input shape {rhs.shape} are not compatible for matmul (second index of first shape ({lhs.shape[-1].value}) must be equal to first index of second shape ({rhs.shape[-2].value})"
         assert self.builder.codegen_fns.get(
             "min_dot_size") is not None, "target doesn't provide lower shape bounds for dot."
+        if resolve_dot is not None:
+            # queried after the legacy e4b15/fnuz upcasts above so rules see the effective dtypes
+            dot_cap = resolve_dot(lhs.dtype.name, rhs.dtype.name, out_dtype.name, lhs.shape[-2].value,
+                                  rhs.shape[-1].value, lhs.shape[-1].value)
+            if not dot_cap.supported:
+                raise ValueError(dot_cap.diag or f"tl.dot: {lhs.dtype} x {rhs.dtype} is not supported on this product")
+            if not dot_cap.native:
+                warnings.warn(dot_cap.diag or f"tl.dot: {lhs.dtype} x {rhs.dtype} is not native on this "
+                              "product: emulated path (native=false)")
         min_dot_size = self.builder.codegen_fns["min_dot_size"](lhs.type, rhs.type)
         assert lhs.shape[-2].value >= min_dot_size[0] and lhs.shape[-1].value >= min_dot_size[2] \
             and rhs.shape[-1].value >= min_dot_size[1], \
@@ -1653,6 +1670,16 @@ class TritonSemantic(Generic[TensorTy]):
         allowed_formats = {"e2m1", "e4m3", "e5m2", "bf16", "fp16"}
         assert lhs_format in allowed_formats, f"NYI: lhs_format {lhs_format}"
         assert rhs_format in allowed_formats, f"NYI: rhs_format {rhs_format}"
+        # non-native (decomposed) format combinations warn at compile time
+        resolve_dot_scaled = self.builder.codegen_fns.get("resolve_dot_scaled")
+        if resolve_dot_scaled is not None:
+            scaled_cap = resolve_dot_scaled(lhs_format, rhs_format)
+            if not scaled_cap.supported:
+                raise ValueError(scaled_cap.diag
+                                 or f"tl.dot_scaled: {lhs_format} x {rhs_format} is not supported on this product")
+            if not scaled_cap.native:
+                warnings.warn(scaled_cap.diag or f"tl.dot_scaled: {lhs_format} x {rhs_format} is not native "
+                              "on this product: decomposed to an emulated path (native=false)")
         rhs_scale_is_none = rhs_scale is None or (isinstance(rhs_scale, tl.constexpr) and rhs_scale.value is None)
         lhs_scale_is_none = lhs_scale is None or (isinstance(lhs_scale, tl.constexpr) and lhs_scale.value is None)
         lhs = self._bitcast_to_fp_type(lhs, lhs_format)

--- a/third_party/mthreads/spec/triton/runtime/interpreter.py
+++ b/third_party/mthreads/spec/triton/runtime/interpreter.py
@@ -200,67 +200,123 @@ def _get_np_dtype(tt_dtype):
     return np_types[tt_dtype]
 
 
+def _float_special_kind(dtype):
+    """Special-value convention of a float format:
+    "ieee": inf at e=max/m=0, nan at e=max/m!=0 (fp16/bf16/fp32/fp64/fp8e5)
+    "fn":   no inf; nan is all-ones exponent + all-ones mantissa (fp8e4nv)
+    "fnuz": no inf; nan is the sign bit only (fp8e4b8 / fp8e5b16)
+    "none": neither inf nor nan (fp8e4b15)
+    """
+    return {
+        tl.float8e4nv: "fn",
+        tl.float8e4b8: "fnuz",
+        tl.float8e5b16: "fnuz",
+        tl.float8e4b15: "none",
+    }.get(dtype, "ieee")
+
+
+def _decode_float_to_fp64(bits, dtype):
+    """Decode raw bit patterns of `dtype` into exact float64 values."""
+    if dtype == tl.float64:
+        return bits.view(np.float64).copy()
+    if dtype == tl.float32:
+        return bits.view(np.float32).astype(np.float64)
+    if dtype == tl.float16:
+        return bits.view(np.float16).astype(np.float64)
+    if dtype == tl.bfloat16:
+        return (bits.astype(np.uint32) << 16).view(np.float32).astype(np.float64)
+    mw = dtype.fp_mantissa_width
+    ew = dtype.primitive_bitwidth - mw - 1
+    bias = dtype.exponent_bias
+    kind = _float_special_kind(dtype)
+    b = bits.astype(np.int64)
+    sign = np.where((b >> (mw + ew)) & 1, -1.0, 1.0)
+    e = (b >> mw) & ((1 << ew) - 1)
+    m = b & ((1 << mw) - 1)
+    normal = np.ldexp(1.0 + m / (1 << mw), (e - bias).astype(np.int32))
+    subnormal = np.ldexp(m / (1 << mw), np.int32(1 - bias))
+    val = sign * np.where(e == 0, subnormal, normal)
+    e_max = (1 << ew) - 1
+    if kind == "ieee":
+        val = np.where((e == e_max) & (m == 0), sign * np.inf, val)
+        val = np.where((e == e_max) & (m != 0), np.nan, val)
+    elif kind == "fn":
+        val = np.where((e == e_max) & (m == (1 << mw) - 1), np.nan, val)
+    elif kind == "fnuz":
+        val = np.where(b == (1 << (mw + ew)), np.nan, val)
+    return val
+
+
+def _encode_fp64_to_float(val, dtype, rounding_mode):
+    """Encode float64 values into raw bit patterns of `dtype` with strict
+    RTNE/RTZ rounding; formats without inf saturate to max finite."""
+    mw = dtype.fp_mantissa_width
+    ew = dtype.primitive_bitwidth - mw - 1
+    bias = dtype.exponent_bias
+    kind = _float_special_kind(dtype)
+    e_max = (1 << ew) - 1
+    val = np.ascontiguousarray(val, dtype=np.float64)
+    b64 = val.view(np.uint64).astype(np.int64)
+    sign = (b64 >> 63) & 1
+    e_in = (b64 >> 52) & 0x7FF
+    m_in = b64 & ((1 << 52) - 1)
+    is_nan = np.isnan(val)
+    is_inf = np.isinf(val)
+    # significand with implicit bit; float64 subnormals have no implicit bit
+    denorm_in = e_in == 0
+    sig = np.where(denorm_in, m_in, m_in | (1 << 52))
+    unbiased = np.where(denorm_in, -1022, e_in - 1023)
+    # E <= 0 lands in the target's subnormal range and needs extra right-shifts
+    E = unbiased + bias
+    k = np.clip((52 - mw) + np.maximum(0, 1 - E), 0, 62)
+    keep = sig >> k
+    rem = sig & ((np.int64(1) << k) - 1)
+    if rounding_mode is None or rounding_mode == _ir.ROUNDING_MODE.RTNE:
+        half = np.where(k > 0, np.int64(1) << np.maximum(k - 1, 0), np.int64(0))
+        round_up = ((rem > half) | ((rem == half) & ((keep & 1) == 1))) & (k > 0)
+        keep = keep + round_up
+    elif rounding_mode == _ir.ROUNDING_MODE.RTZ:
+        pass
+    else:
+        raise ValueError(f"unsupported rounding mode {rounding_mode}")
+    # (E << mw) + keep - 2^mw lets a mantissa carry overflow into the exponent;
+    # in the subnormal case keep == 2^mw naturally becomes the minimum normal
+    expmant = np.where(E >= 1, (E << mw) + keep - (1 << mw), keep)
+    if kind == "ieee":
+        inf_code = e_max << mw
+        max_finite = inf_code - 1
+        if rounding_mode == _ir.ROUNDING_MODE.RTZ:
+            expmant = np.minimum(expmant, max_finite)  # RTZ never rounds to inf
+        else:
+            expmant = np.where(expmant >= inf_code, inf_code, expmant)
+        result = (sign << (mw + ew)) | expmant
+        result = np.where(is_inf, (sign << (mw + ew)) | inf_code, result)
+        result = np.where(is_nan, (sign << (mw + ew)) | inf_code | (1 << (mw - 1)), result)
+    elif kind == "fn":
+        max_finite = (e_max << mw) | ((1 << mw) - 2)
+        expmant = np.minimum(expmant, max_finite)  # satfinite (also maps inf)
+        result = (sign << (mw + ew)) | expmant
+        result = np.where(is_nan, (e_max << mw) | ((1 << mw) - 1), result)
+    elif kind == "fnuz":
+        max_finite = (e_max << mw) | ((1 << mw) - 1)
+        expmant = np.minimum(expmant, max_finite)
+        # fnuz has no -0 (the sign-only pattern is the NaN code): anything
+        # that rounds to zero encodes as +0
+        result = np.where(expmant == 0, np.int64(0), (sign << (mw + ew)) | expmant)
+        result = np.where(is_nan, np.int64(1) << (mw + ew), result)
+    else:  # "none" (fp8e4b15): no inf/nan representation, saturate
+        max_finite = (e_max << mw) | ((1 << mw) - 1)
+        expmant = np.minimum(expmant, max_finite)
+        result = (sign << (mw + ew)) | expmant
+    out_uint_dtype = getattr(np, f"uint{dtype.primitive_bitwidth}")
+    return result.astype(out_uint_dtype)
+
+
 def _convert_float(input, input_dtype, output_dtype, rounding_mode):
     input_uint_dtype = getattr(np, f"uint{input_dtype.primitive_bitwidth}")
-    output_unint_dtype = getattr(np, f"uint{output_dtype.primitive_bitwidth}")
-    input_bin = np.frombuffer(input.tobytes(), dtype=input_uint_dtype)
-    sign = (input_bin >> (input_dtype.primitive_bitwidth - 1)) & 0x01
-    input_exponent_width = input_dtype.primitive_bitwidth - input_dtype.fp_mantissa_width - 1
-    output_exponent_width = output_dtype.primitive_bitwidth - output_dtype.fp_mantissa_width - 1
-    significand = input_bin & ((1 << input_dtype.fp_mantissa_width) - 1)
-    bias_input = input_dtype.exponent_bias
-    bias_output = output_dtype.exponent_bias
-    exponent = ((input_bin >> input_dtype.fp_mantissa_width) & ((1 << input_exponent_width) - 1)).astype(np.int32)
-    subnormal_index = exponent == 0
-    if np.any(subnormal_index):
-        # Credit to Phil: phil@openai.com
-        # subnormal repr: ((-1.0)**sign) * (2.0**(1 - exp_bias)) * (2^(m0) + 2^(m1) + ... + 2^(mn))
-        # where m0, m1, ..., mn are the 1-bit of the mantissa
-        # convert it to normal repr: ((-1.0)**sign) * (2.0**(1 + m0 - exp_bias)) * (1 + 2^(m1 - m0) + ... + 2^(mn - m0))
-        bit_pos = np.zeros_like(input_bin, dtype=np.int32)
-        # Find the most significant bit of the mantissa in the significand
-        for i in range(input_dtype.fp_mantissa_width):
-            bit_index = ((significand >> i) & 0x01)
-            # pos should be >= 1
-            bit_pos[bit_index == 1] = input_dtype.fp_mantissa_width - i
-        zero_significand_index = significand == 0
-        exponent[subnormal_index] = 1 - bit_pos[subnormal_index]
-        # 0 significand and subnormal should be treated as 0
-        exponent[zero_significand_index & subnormal_index] = bias_input - bias_output
-        significand[subnormal_index] = (significand[subnormal_index] << bit_pos[subnormal_index]) & (
-            (1 << input_dtype.fp_mantissa_width) - 1)
-    # Prevent overflow and underflow
-    exponent_output = np.maximum(0, np.minimum((exponent - bias_input + bias_output), (1 << output_exponent_width) - 1))
-    exponent_output = exponent_output.astype(output_unint_dtype)
-    sign_output = sign.astype(output_unint_dtype)
-    if input_dtype.primitive_bitwidth > output_dtype.primitive_bitwidth:  # Downcast
-        significand_output = (significand >> (input_dtype.fp_mantissa_width - output_dtype.fp_mantissa_width)) & (
-            (1 << output_dtype.fp_mantissa_width) - 1)
-        if rounding_mode == _ir.ROUNDING_MODE.RTNE:  # Round to nearst even
-            # find the cut-off bit
-            cut_off = significand & (1 << (input_dtype.fp_mantissa_width - output_dtype.fp_mantissa_width - 1))
-            significand_output = significand_output + (cut_off > 0)
-        significand_output = significand_output.astype(output_unint_dtype)
-    else:  # Upcast
-        significand_output = (significand.astype(output_unint_dtype) <<
-                              (output_dtype.fp_mantissa_width - input_dtype.fp_mantissa_width)) & (
-                                  (1 << output_dtype.fp_mantissa_width) - 1)
-    subnormal_index = exponent_output == 0
-    if np.any(subnormal_index):  # underflow
-        # normal repr: ((-1.0)**sign) * (2.0**(exp - exp_bias_input)) * (1 + 2^(m0) + 2^(m1) + ... + 2^(mn))
-        # where m0, m1, ..., mn are the 1-bit of the mantissa
-        # shift = (1 - exp_bias_output) - (exp - exp_bias_input)
-        # convert it to subnormal repr: ((-1.0)**sign) * (2.0**(1 - exp_bias_output)) * (2^(-shift) + 2^(m0 - shift) + 2^(m1 - shift) + ... + 2^(mn - shift))
-        exponent = ((input_bin >> input_dtype.fp_mantissa_width) & ((1 << input_exponent_width) - 1)).astype(np.int32)
-        non_zero_exponent_index = exponent != 0
-        # If the original exponent is not zero, we still need to shift the significand and consider the 1.0 part in mantissa
-        subnormal_index = subnormal_index & non_zero_exponent_index
-        shift = np.zeros_like(input_bin, dtype=np.int32)
-        shift[subnormal_index] = (1 - bias_output) - (exponent[subnormal_index] - bias_input)
-        significand_output[subnormal_index] = (significand_output[subnormal_index] >> shift[subnormal_index]) | (
-            1 << (output_dtype.fp_mantissa_width - shift[subnormal_index]))
-    output = (sign_output << (output_dtype.primitive_bitwidth - 1)) | (
-        exponent_output << output_dtype.fp_mantissa_width) | significand_output
+    input_bits = np.frombuffer(input.tobytes(), dtype=input_uint_dtype)
+    val = _decode_float_to_fp64(input_bits, input_dtype)
+    output = _encode_fp64_to_float(val, output_dtype, rounding_mode)
     return output.reshape(input.shape)
 
 

--- a/third_party/mthreads/triton_mthreads.cc
+++ b/third_party/mthreads/triton_mthreads.cc
@@ -237,9 +237,14 @@ void init_triton_musa_passes_ttgpuir(py::module m) {
   m.def("add_mtgpu_to_llvm", [](mlir::PassManager &pm, int32_t capability) {
     pm.addPass(mlir::triton::createConvertMTGPUToLLVMPass(capability));
   });
-  m.def("add_to_llvmir", [](mlir::PassManager &pm, int32_t capability) {
-    pm.addPass(mlir::triton::createConvertTritonMUSAGPUToLLVMPass(capability));
-  });
+  m.def(
+      "add_to_llvmir",
+      [](mlir::PassManager &pm, int32_t capability, bool enableFp8Burst2) {
+        pm.addPass(mlir::triton::createConvertTritonMUSAGPUToLLVMPass(
+            capability, enableFp8Burst2));
+      },
+      py::arg("pm"), py::arg("capability"),
+      py::arg("enable_fp8_burst2") = false);
   m.def("add_allocate_shared_memory", [](mlir::PassManager &pm,
                                          int32_t capability) {
     pm.addPass(mlir::triton::createAllocateMUSASharedMemoryPass(capability));


### PR DESCRIPTION
> **Depends on #1112** — this branch is stacked on `feature/precision-core`; the first commit is that PR. Please review only the second commit (`third_party/mthreads/` only). Will rebase once #1112 merges.

## Summary

MThreads implementation of the low-precision float capability contract from #1112.

- **`backend/compiler.py`**: dual-whitelist field family — `supported_fp8_dtypes` (dot operands) vs `supported_fp8_storage_dtypes` (storage-only fnuz/e4b15 formats stay out of `tl.dot`); `supported_fp8_cast_dtypes` / `custom_cast_fp8_dtypes` (renamed from `custom_fp8_dtypes`); `resolve_dot` — same-type OCP fp8 dot with fp32 accumulator is native from cap31 when the block shape hits an 8-bit instruction tile, otherwise `EMULATED` via the FMA fallback with the concrete reason in the diagnostic; `resolve_dot_scaled` — always `EMULATED` (no native scaled-MMA path).
- **`AccelerateMUSAMatmul.cpp`**: SQMMA operands staged through a same-width bit container (i8 loads bitcast to fp8) are retyped with `MemDescReinterpretOp` to the element type the dot consumes; accelerated WMMA now bails out to the FMA fallback for fp16 accumulators/results outside the PH1 f16×f16 carrier path.
- **`Utility.cpp`**: `replaceUsesAndPropagateType` handles same-shape `MemDescReinterpretOp` views.
- **`Dialect.cpp`**: `WmmaDotOp::verify` requires A/B to share an element type (previously only bit width was checked, so e.g. fp8e4nv × fp8e5 passed the verifier and lowered incorrectly).
- **`enable_fp8_burst2`**: plumbed from `MUSAOptions` through the pass pipeline instead of `getenv` at lowering time, so it participates in the compile cache key; the pybind signature keeps a default for backward compatibility.
- **`spec/triton/`**: the overlay copies of `backends/compiler.py`, `language/semantic.py`, `runtime/interpreter.py` mirror the #1112 changes; the shared helper blocks are byte-identical to the core files (verified by diff), adapted only around the spec's `_assert_dot_dtypes_valid` dual-whitelist gate.

## Behavior changes to be aware of

- `custom_fp8_dtypes` → `custom_cast_fp8_dtypes` rename changes the options dataclass, which invalidates existing compile caches (no code references the old name anywhere in the tree).
- `WmmaDotOp::verify` is stricter (same element type), which could reject IR that previously passed verification with mixed same-width operand types; no in-tree pass emits such IR.
