### PR TITLE
[CI][Nvidia] Optimize concurrency grouping for nvidia3.6 workflow

### DIFF
--- a/.github/workflows/nvidia3.6-build-and-test.yml
+++ b/.github/workflows/nvidia3.6-build-and-test.yml
@@ -34,7 +34,13 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  # Group by PR number for pull_request events to cancel outdated runs from the same PR.
+  # Group by commit SHA for push events to allow parallel runs from different merges.
+  # Fall back to run_id for other events (e.g., schedule) to ensure each run is independent.
+  group: ${{ github.workflow }}-${{
+    github.event_name == 'pull_request' && github.event.pull_request.number ||
+    github.event_name == 'push' && github.event.head_commit.id ||
+    github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Refine the concurrency group logic to better handle different event types:
- pull_request: Group by PR number to cancel outdated runs from the same PR.
- push: Group by commit SHA to allow parallel runs from different merges.
- schedule/others: Fall back to run_id to keep each scheduled run independent.

<!-- PR Title Format:
[TLE][BUILD][TEST][CI/CD][DOC][PROTON][BACKEND][FLIR] Brief description
[LANGUAGE][AUTOTUNER][LAYOUT][PIPELINE][WarpSpecialization] Brief description
Do not set the following title tags: [FEATURE][BUG][FixBug][Refine] ...
-->
