### PR TITLE
[QC][TLE][Nvidia] Barrier & Sync Optimization

### DIFF
--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -607,16 +607,35 @@ void MembarAnalysis::update(Operation *op, BlockInfo *blockInfo,
       // all-shared-memory dependency because one elected lane cannot publish
       // stores performed by other lanes without a preceding barrier.
       if (!arrive.getParticipantArrive()) {
+        // The dependency only orders the arrive against *prior* accesses, so
+        // check it with a transient probe instead of joining it into the
+        // running state; otherwise every later shared-memory op would
+        // spuriously conflict with this arrive until the next barrier.
         Interval<size_t> allIntervals(0, std::numeric_limits<size_t>::max());
-        curBlockInfo.syncWriteIntervals[allIntervals].insert(op);
-        curBlockInfo.syncReadIntervals[allIntervals].insert(op);
+        BlockInfo probeInfo;
+        probeInfo.syncWriteIntervals[allIntervals].insert(op);
+        probeInfo.syncReadIntervals[allIntervals].insert(op);
+        if (blockInfo->isIntersected(probeInfo, filter)) {
+          builder->setInsertionPoint(op);
+          insertBarrier(op, builder);
+          blockInfo->sync();
+        }
       }
     }
 #else
     if (isa<triton::nvidia_gpu::ArriveBarrierOp>(op)) {
+      // Probe against prior unsynced accesses to decide on a pre-arrive
+      // rendezvous, without leaking the all-shared-memory interval into the
+      // running state (see the TLE path above).
       Interval<size_t> allIntervals(0, std::numeric_limits<size_t>::max());
-      curBlockInfo.syncWriteIntervals[allIntervals].insert(op);
-      curBlockInfo.syncReadIntervals[allIntervals].insert(op);
+      BlockInfo probeInfo;
+      probeInfo.syncWriteIntervals[allIntervals].insert(op);
+      probeInfo.syncReadIntervals[allIntervals].insert(op);
+      if (blockInfo->isIntersected(probeInfo, filter)) {
+        builder->setInsertionPoint(op);
+        insertBarrier(op, builder);
+        blockInfo->sync();
+      }
     }
 #endif
     scratchBufferId = allocation->getBufferId(op);

--- a/lib/Analysis/Membar.cpp
+++ b/lib/Analysis/Membar.cpp
@@ -206,6 +206,19 @@ static std::optional<StaticAccessView> getStaticMemDescView(Value value) {
     return srcView;
   }
 
+  if (auto arg = dyn_cast<BlockArgument>(value)) {
+    // A block argument carries no static offset information. Warp-specialize
+    // partition arguments map positionally to the parent's captures, so the
+    // view can be recovered there; any other block argument must give up so
+    // the caller falls back to the whole allocated interval instead of
+    // wrongly assuming the view starts at the buffer base.
+    if (auto partitions = dyn_cast<ttg::WarpSpecializePartitionsOp>(
+            arg.getOwner()->getParentOp()))
+      return getStaticMemDescView(
+          partitions.getParentOp().getExplicitCaptures()[arg.getArgNumber()]);
+    return std::nullopt;
+  }
+
   SmallVector<int64_t> shape(memDescTy.getShape().begin(),
                              memDescTy.getShape().end());
   return StaticAccessView{value, SmallVector<int64_t>(shape.size(), 0),

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -364,6 +364,13 @@ bool NVIDIA::canSkipBarSync(Operation *before, Operation *after) {
       isa<triton::nvidia_gpu::WaitBarrierOp>(after))
     return false;
 
+  // An arrive followed by a wait only touches mbarrier objects, which the
+  // mbarrier hardware orders by itself; the rendezvous inserted before the
+  // arrive already covers its publication, so no extra barrier is needed.
+  if (isa<triton::nvidia_gpu::ArriveBarrierOp>(before) &&
+      isa<triton::nvidia_gpu::WaitBarrierOp>(after))
+    return true;
+
   // Even though WaitBarrierOp, AsyncTMACopyGlobalToLocalOp and
   // AsyncTMACopyGlobalToLocalOp read and write to the mbarrier allocation it is
   // valid for them to happen in different order on different threads, therefore

--- a/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
+++ b/third_party/nvidia/lib/TritonNVIDIAGPUToLLVM/TritonGPUToLLVM.cpp
@@ -364,11 +364,13 @@ bool NVIDIA::canSkipBarSync(Operation *before, Operation *after) {
       isa<triton::nvidia_gpu::WaitBarrierOp>(after))
     return false;
 
-  // An arrive followed by a wait only touches mbarrier objects, which the
-  // mbarrier hardware orders by itself; the rendezvous inserted before the
-  // arrive already covers its publication, so no extra barrier is needed.
+  // An arrive followed by a wait or another arrive only touches mbarrier
+  // objects, which the mbarrier hardware orders by itself; the rendezvous
+  // inserted before the first arrive already covers its publication, so no
+  // extra barrier is needed.
   if (isa<triton::nvidia_gpu::ArriveBarrierOp>(before) &&
-      isa<triton::nvidia_gpu::WaitBarrierOp>(after))
+      isa<triton::nvidia_gpu::WaitBarrierOp,
+          triton::nvidia_gpu::ArriveBarrierOp>(after))
     return true;
 
   // Even though WaitBarrierOp, AsyncTMACopyGlobalToLocalOp and


### PR DESCRIPTION
<!-- PR Title Format:
[TLE][BUILD][TEST][CI/CD][DOC][PROTON][BACKEND][FLIR] Brief description
[LANGUAGE][AUTOTUNER][LAYOUT][PIPELINE][WarpSpecialization] Brief description
Do not set the following title tags: [FEATURE][BUG][FixBug][Refine] ...
-->

1. Avoid redundant barrier around barrier_arrive.
2. Better interval refinement for warp specialization.

# Reproduce scripts

## for 1

```python
#!/usr/bin/env python3
"""
Semantics (identical to min_wait_cuda.cu):
  two warp groups in one CTA, double-buffered ping-pong over shared memory.
  producer: wait(empty[s], phase i-1) -> store slot -> arrive(full[s], i)
  consumer: wait(full[s],  phase i)   -> load slot  -> arrive(empty[s], i)
This is exactly the steady-loop wait skeleton of the SnapMLA decode kernel,
with all math removed.

Usage: min_wait_tle.py <cache_root> [n_time_iters]
Prints VERIFY_OK, per-iteration timing, and dumps SASS of the compiled cubin.
"""
import os
import subprocess
import sys
from pathlib import Path

CACHE = sys.argv[1]
N_TIME = int(sys.argv[2]) if len(sys.argv) > 2 else 100000
os.environ["TRITON_CACHE_DIR"] = CACHE

import torch
import triton
import triton.language as tl
import triton.experimental.tle.language as tle

BK = 128


@triton.jit
def _producer(s0, s1, full0, full1, empty0, empty1, n_iters, BK: tl.constexpr):
    offs = tl.arange(0, BK)
    base = offs.to(tl.float32)
    tl.store(tle.gpu.local_ptr(s0, (offs,)), base)
    tle.gpu.barrier_arrive(full0, phaseIdx=0)
    tl.store(tle.gpu.local_ptr(s1, (offs,)), base + 1.0)
    tle.gpu.barrier_arrive(full1, phaseIdx=0)
    for i in tl.range(1, n_iters, disable_licm=True):
        fi = i.to(tl.float32)
        tle.gpu.barrier_wait(empty0, phaseIdx=i - 1)
        tl.store(tle.gpu.local_ptr(s0, (offs,)), base + 2.0 * fi)
        tle.gpu.barrier_arrive(full0, phaseIdx=i)
        tle.gpu.barrier_wait(empty1, phaseIdx=i - 1)
        tl.store(tle.gpu.local_ptr(s1, (offs,)), base + 2.0 * fi + 1.0)
        tle.gpu.barrier_arrive(full1, phaseIdx=i)


@triton.jit
def _consumer(out_ptr, s0, s1, full0, full1, empty0, empty1, n_iters, BK: tl.constexpr):
    offs = tl.arange(0, BK)
    acc = tl.zeros((BK,), dtype=tl.float32)
    for i in tl.range(0, n_iters, disable_licm=True):
        tle.gpu.barrier_wait(full0, phaseIdx=i)
        acc += tl.load(tle.gpu.local_ptr(s0, (offs,)))
        tle.gpu.barrier_arrive(empty0, phaseIdx=i)
        tle.gpu.barrier_wait(full1, phaseIdx=i)
        acc += tl.load(tle.gpu.local_ptr(s1, (offs,)))
        tle.gpu.barrier_arrive(empty1, phaseIdx=i)
    tl.store(out_ptr + offs, acc)


@triton.jit
def min_wait_kernel(out_ptr, n_iters, BK: tl.constexpr):
    s0 = tle.gpu.alloc([BK], dtype=tl.float32, scope=tle.gpu.smem)
    s1 = tle.gpu.alloc([BK], dtype=tl.float32, scope=tle.gpu.smem)
    bars = tle.gpu.alloc_barriers(num_barriers=4, arrive_count=1)
    tle.gpu.warp_specialize(
        [
            (_producer, (s0, s1, bars[0], bars[1], bars[2], bars[3], n_iters, BK)),
            (_consumer, (out_ptr, s0, s1, bars[0], bars[1], bars[2], bars[3], n_iters, BK)),
        ],
        [4],
        [255],
    )


def expected(n: int) -> torch.Tensor:
    offs = torch.arange(BK, dtype=torch.float64, device="cuda")
    return (n * (2.0 * offs + 1.0) + 2.0 * n * (n - 1)).to(torch.float32)


def main() -> None:
    torch.cuda.set_device(0)
    out = torch.zeros(BK, dtype=torch.float32, device="cuda")

    # Correctness at small n (values exact in fp32).
    n_check = 100
    min_wait_kernel[(1,)](out, n_check, BK, num_warps=4)
    torch.cuda.synchronize()
    ok = torch.equal(out, expected(n_check))
    print(f"VERIFY_OK={ok} sample={out[:4].tolist()}")
    if not ok:
        raise SystemExit(1)

    # Timing at large n: cost is pure ping-pong sync + tiny LDS/STS.
    for _ in range(3):
        min_wait_kernel[(1,)](out, N_TIME, BK, num_warps=4)
    torch.cuda.synchronize()
    start, end = torch.cuda.Event(True), torch.cuda.Event(True)
    reps = 5
    start.record()
    for _ in range(reps):
        min_wait_kernel[(1,)](out, N_TIME, BK, num_warps=4)
    end.record()
    torch.cuda.synchronize()
    ms = start.elapsed_time(end) / reps
    print(f"TLE_TOTAL_MS={ms:.3f} TLE_NS_PER_ITER={ms * 1e6 / N_TIME:.1f}")

    # Dump SASS of the compiled cubin.
    cubins = list(Path(CACHE).rglob("*.cubin"))
    print(f"CUBINS={[str(c) for c in cubins]}")
    for c in cubins:
        sass = c.with_suffix(".sass")
        with sass.open("w") as f:
            subprocess.run(
                ["/usr/local/cuda-12.8/bin/nvdisasm", "-c", str(c)],
                stdout=f, check=True,
            )
        print(f"SASS={sass}")


if __name__ == "__main__":
    main()

```


## for 2

```python
#!/usr/bin/env python3
"""

A partition writes slot0 and reads slot1 of a double-buffered smem region
every iteration (truly disjoint -- no barrier is semantically needed).

  kernel_slotview:  slot views of ONE [2,BK] alloc are captured into the
                    partition -> Membar's interval refinement collapses both
                    views to the buffer base -> spurious RAW/WAR every
                    iteration -> redundant bar.sync per iteration.
  kernel_twoalloc:  identical code, but slots are TWO separate allocs
                    (distinct buffers never collapse) -> zero barriers.
                    This is the expected performance once A2 is fixed.

Usage: min_collapse_tle.py <cache_root> [n_time_iters]
"""
import os
import sys

CACHE = sys.argv[1]
N_TIME = int(sys.argv[2]) if len(sys.argv) > 2 else 100000
os.environ["TRITON_CACHE_DIR"] = CACHE

import torch
import triton
import triton.language as tl
import triton.experimental.tle.language as tle

# The nvidia frontend gates buffered_tensor.slot behind a primitive
# whitelist. The generated IR (ttg.memdesc_index) is identical to what
# alloc_barriers slot indexing and the pipe lowering produce, so we
# enable it here purely to construct the repro.
import triton.backends.nvidia.tle_supported as _tle_sup
if 'gpu.buffered_tensor.slot' not in _tle_sup.TLE_SUPPORTED_PRIMITIVES:
    _tle_sup.TLE_SUPPORTED_PRIMITIVES.append('gpu.buffered_tensor.slot')


BK = 128


@triton.jit
def _idle():
    pass


@triton.jit
def _worker(out_ptr, s0, s1, n_iters, BK: tl.constexpr):
    offs = tl.arange(0, BK)
    base = offs.to(tl.float32)
    tl.store(tle.gpu.local_ptr(s1), base)
    acc = tl.zeros((BK,), dtype=tl.float32)
    for i in tl.range(0, n_iters, disable_licm=True):
        tl.store(tle.gpu.local_ptr(s0), base + i.to(tl.float32))
        acc += tl.load(tle.gpu.local_ptr(s1))
    tl.store(out_ptr + offs, acc)


@triton.jit
def kernel_slotview(out_ptr, n_iters, BK: tl.constexpr):
    s = tle.gpu.alloc([2, BK], dtype=tl.float32, scope=tle.gpu.smem)
    s0 = s.slot(0)
    s1 = s.slot(1)
    tle.gpu.warp_specialize(
        [(_idle, ()), (_worker, (out_ptr, s0, s1, n_iters, BK))],
        [4],
        [255],
    )


@triton.jit
def kernel_twoalloc(out_ptr, n_iters, BK: tl.constexpr):
    a = tle.gpu.alloc([BK], dtype=tl.float32, scope=tle.gpu.smem)
    b = tle.gpu.alloc([BK], dtype=tl.float32, scope=tle.gpu.smem)
    tle.gpu.warp_specialize(
        [(_idle, ()), (_worker, (out_ptr, a, b, n_iters, BK))],
        [4],
        [255],
    )


def run(kernel, name):
    out = torch.zeros(BK, dtype=torch.float32, device="cuda")
    n_check = 100
    kernel[(1,)](out, n_check, BK, num_warps=4)
    torch.cuda.synchronize()
    offs = torch.arange(BK, dtype=torch.float32, device="cuda")
    ok = torch.equal(out, n_check * offs)
    print(f"{name}_VERIFY_OK={ok} sample={out[:4].tolist()}")
    if not ok:
        raise SystemExit(1)

    for _ in range(3):
        kernel[(1,)](out, N_TIME, BK, num_warps=4)
    torch.cuda.synchronize()
    start, end = torch.cuda.Event(True), torch.cuda.Event(True)
    reps = 5
    start.record()
    for _ in range(reps):
        kernel[(1,)](out, N_TIME, BK, num_warps=4)
    end.record()
    torch.cuda.synchronize()
    ms = start.elapsed_time(end) / reps
    print(f"{name}_NS_PER_ITER={ms * 1e6 / N_TIME:.1f}")


def main():
    torch.cuda.set_device(0)
    run(kernel_slotview, "SLOTVIEW")
    run(kernel_twoalloc, "TWOALLOC")


if __name__ == "__main__":
    main()

```