### PR TITLE
[TLERaw] Add NVSHMEM allreduce RMSNorm tutorial

### DIFF
--- a/python/tutorials/tle/raw/nvshmem/05-allreduce-rmsnorm/allreduce-device.cu
+++ b/python/tutorials/tle/raw/nvshmem/05-allreduce-rmsnorm/allreduce-device.cu
@@ -1,0 +1,121 @@
+// Copyright 2026, The FlagOS Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+
+#include <cstdint>
+
+namespace {
+
+constexpr int kHiddenSize = 2048;
+constexpr int kVectorWidth = 8;
+constexpr int kMaxRanks = 8;
+
+struct Float8 {
+  float data[8];
+};
+
+union PackedBF16x2 {
+  uint32_t bits;
+  __nv_bfloat162 values;
+};
+
+__device__ __forceinline__ void fence_proxy_alias() {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 900
+  asm volatile("fence.proxy.alias;" ::: "memory");
+#endif
+}
+
+__device__ __forceinline__ Float8 load_bf16x8(const __nv_bfloat16 *address) {
+  PackedBF16x2 p0, p1, p2, p3;
+  p0.values = *reinterpret_cast<const __nv_bfloat162 *>(address + 0);
+  p1.values = *reinterpret_cast<const __nv_bfloat162 *>(address + 2);
+  p2.values = *reinterpret_cast<const __nv_bfloat162 *>(address + 4);
+  p3.values = *reinterpret_cast<const __nv_bfloat162 *>(address + 6);
+
+  const float2 f0 = __bfloat1622float2(p0.values);
+  const float2 f1 = __bfloat1622float2(p1.values);
+  const float2 f2 = __bfloat1622float2(p2.values);
+  const float2 f3 = __bfloat1622float2(p3.values);
+
+  return {f0.x, f0.y, f1.x, f1.y, f2.x, f2.y, f3.x, f3.y};
+}
+
+__device__ __forceinline__ void store_bf16x8(__nv_bfloat16 *address,
+                                             const Float8 &value) {
+  address[0] = __float2bfloat16_rn(value.data[0]);
+  address[1] = __float2bfloat16_rn(value.data[1]);
+  address[2] = __float2bfloat16_rn(value.data[2]);
+  address[3] = __float2bfloat16_rn(value.data[3]);
+  address[4] = __float2bfloat16_rn(value.data[4]);
+  address[5] = __float2bfloat16_rn(value.data[5]);
+  address[6] = __float2bfloat16_rn(value.data[6]);
+  address[7] = __float2bfloat16_rn(value.data[7]);
+}
+
+__device__ __forceinline__ void add_inplace(Float8 &lhs, const Float8 &rhs) {
+#pragma unroll
+  for (int i = 0; i < 8; ++i) {
+    lhs.data[i] += rhs.data[i];
+  }
+}
+
+} // namespace
+
+extern "C" __device__ __attribute__((always_inline)) void
+fused_allreduce_bf16(__attribute__((address_space(1))) __nv_bfloat16 *reduced_out,
+                     __attribute__((address_space(1))) const int64_t *peer_input_ptrs,
+                     int rank,
+                     int world_size,
+                     int tokens) {
+  if (reduced_out == nullptr || peer_input_ptrs == nullptr ||
+      world_size <= 0 || world_size > kMaxRanks || tokens <= 0) {
+    return;
+  }
+  (void)rank;
+
+  const __nv_bfloat16 *inputs[kMaxRanks];
+#pragma unroll
+  for (int peer = 0; peer < kMaxRanks; ++peer) {
+    if (peer < world_size) {
+      inputs[peer] =
+          reinterpret_cast<const __nv_bfloat16 *>(peer_input_ptrs[peer]);
+    }
+  }
+
+  const int packed_per_row = kHiddenSize / kVectorWidth;
+
+  fence_proxy_alias();
+  __syncthreads();
+
+  for (int row = 0; row < tokens; ++row) {
+    const int base_row = row * kHiddenSize;
+    for (int packed = threadIdx.x; packed < packed_per_row;
+         packed += blockDim.x) {
+      const int base = base_row + packed * kVectorWidth;
+      Float8 reduced = load_bf16x8(inputs[0] + base);
+#pragma unroll
+      for (int peer = 1; peer < kMaxRanks; ++peer) {
+        if (peer < world_size) {
+          add_inplace(reduced, load_bf16x8(inputs[peer] + base));
+        }
+      }
+      store_bf16x8(reduced_out + base, reduced);
+    }
+  }
+
+  __syncthreads();
+  fence_proxy_alias();
+}

--- a/python/tutorials/tle/raw/nvshmem/05-allreduce-rmsnorm/allreduce-host.cu
+++ b/python/tutorials/tle/raw/nvshmem/05-allreduce-rmsnorm/allreduce-host.cu
@@ -1,0 +1,169 @@
+// Copyright 2026, The FlagOS Contributors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cuda_bf16.h>
+#include <cuda_runtime.h>
+#include <nvshmem.h>
+#include <nvshmemx.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+
+#define CUDA_CHECK_RET(stmt, code)                                           \
+  do {                                                                       \
+    cudaError_t result_ = (stmt);                                            \
+    if (result_ != cudaSuccess) {                                            \
+      std::fprintf(stderr, "[%s:%d] CUDA failed: %s\n", __FILE__, __LINE__,  \
+                   cudaGetErrorString(result_));                             \
+      return (code);                                                         \
+    }                                                                        \
+  } while (0)
+
+__global__ void publish_ready_kernel(uint64_t *slot, uint64_t epoch) {
+  if (blockIdx.x == 0 && threadIdx.x == 0) {
+    __threadfence_system();
+    *slot = epoch;
+    __threadfence_system();
+  }
+}
+
+static int launch_publish_ready(uint64_t *slot, uint64_t epoch,
+                                cudaStream_t stream) {
+  publish_ready_kernel<<<1, 1, 0, stream>>>(slot, epoch);
+  cudaError_t result = cudaGetLastError();
+  if (result != cudaSuccess) {
+    std::fprintf(stderr, "[%s:%d] publish ready launch failed: %s\n",
+                 __FILE__, __LINE__, cudaGetErrorString(result));
+    return -1;
+  }
+  return 0;
+}
+
+extern "C" int tle_ar_rmsnorm_workspace_create(
+    int capacity_tokens,
+    int hidden_size,
+    void **input_unicast,
+    void **ready_unicast,
+    cudaStream_t *stream,
+    int *mype,
+    int *npes,
+    int *mype_in_node,
+    int *npes_in_node) {
+  if (capacity_tokens <= 0 || hidden_size != 2048 || input_unicast == nullptr ||
+      ready_unicast == nullptr || stream == nullptr || mype == nullptr ||
+      npes == nullptr || mype_in_node == nullptr || npes_in_node == nullptr) {
+    return -1;
+  }
+
+  *mype = nvshmem_my_pe();
+  *npes = nvshmem_n_pes();
+  *mype_in_node = nvshmem_team_my_pe(NVSHMEMX_TEAM_NODE);
+  *npes_in_node = nvshmem_team_n_pes(NVSHMEMX_TEAM_NODE);
+
+  if (*npes <= 0 || *npes != *npes_in_node) {
+    return -2;
+  }
+
+  CUDA_CHECK_RET(cudaSetDevice(*mype_in_node), -3);
+
+  int least_priority = 0;
+  int greatest_priority = 0;
+  CUDA_CHECK_RET(cudaDeviceGetStreamPriorityRange(&least_priority,
+                                                  &greatest_priority),
+                 -3);
+  CUDA_CHECK_RET(cudaStreamCreateWithPriority(stream, cudaStreamNonBlocking,
+                                              greatest_priority),
+                 -3);
+
+  const size_t bytes = static_cast<size_t>(capacity_tokens) *
+                       static_cast<size_t>(hidden_size) * sizeof(__nv_bfloat16);
+  *input_unicast = nvshmem_malloc(bytes);
+  *ready_unicast =
+      nvshmem_calloc(static_cast<size_t>(*npes), sizeof(uint64_t));
+
+  if (*input_unicast == nullptr || *ready_unicast == nullptr) {
+    if (*ready_unicast != nullptr) {
+      nvshmem_free(*ready_unicast);
+      *ready_unicast = nullptr;
+    }
+    if (*input_unicast != nullptr) {
+      nvshmem_free(*input_unicast);
+      *input_unicast = nullptr;
+    }
+    cudaStreamDestroy(*stream);
+    *stream = nullptr;
+    return -4;
+  }
+
+  nvshmem_barrier_all();
+  return 0;
+}
+
+extern "C" void *tle_ar_rmsnorm_peer_workspace_ptr(void *workspace, int peer) {
+  return nvshmem_ptr(workspace, peer);
+}
+
+extern "C" int tle_ar_rmsnorm_sync_ready(void *ready_unicast,
+                                         uint64_t epoch,
+                                         int rank,
+                                         int npes,
+                                         cudaStream_t stream) {
+  if (ready_unicast == nullptr || stream == nullptr || epoch == 0 || rank < 0 ||
+      rank >= npes || npes <= 0) {
+    return -1;
+  }
+
+  uint64_t *ready_slots = static_cast<uint64_t *>(ready_unicast);
+  int rc = launch_publish_ready(ready_slots + rank, epoch, stream);
+  if (rc != 0) {
+    return -2;
+  }
+
+  for (int peer = 0; peer < npes; ++peer) {
+    if (peer == rank) {
+      continue;
+    }
+    nvshmemx_signal_op_on_stream(ready_slots + rank, epoch,
+                                 NVSHMEM_SIGNAL_SET, peer, stream);
+  }
+
+  for (int src = 0; src < npes; ++src) {
+    nvshmemx_signal_wait_until_on_stream(ready_slots + src, NVSHMEM_CMP_GE,
+                                         epoch, stream);
+  }
+
+  return 0;
+}
+
+extern "C" int tle_ar_rmsnorm_workspace_destroy(void *input_unicast,
+                                                void *ready_unicast,
+                                                cudaStream_t stream) {
+  if (stream == nullptr) {
+    return -1;
+  }
+
+  CUDA_CHECK_RET(cudaStreamSynchronize(stream), -2);
+  nvshmem_barrier_all();
+
+  if (ready_unicast != nullptr) {
+    nvshmem_free(ready_unicast);
+  }
+  if (input_unicast != nullptr) {
+    nvshmem_free(input_unicast);
+  }
+
+  CUDA_CHECK_RET(cudaStreamDestroy(stream), -3);
+  return 0;
+}

--- a/python/tutorials/tle/raw/nvshmem/05-allreduce-rmsnorm/allreduce.py
+++ b/python/tutorials/tle/raw/nvshmem/05-allreduce-rmsnorm/allreduce.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+# Copyright 2026, The FlagOS Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.distributed as dist
+import triton
+import triton.language as tl
+import triton.experimental.tle.language.raw as tle_raw
+from triton.experimental.tle.raw import dialect
+
+from triton.experimental.tle.raw.nvshmem.utils import (
+    init_nvshmem_by_torch_pg,
+    init_torch_distributed,
+    load_common_host,
+    load_host,
+    tensor_from_pointer,
+)
+
+CODE_DIR = Path(__file__).parent.resolve()
+HIDDEN_SIZE = 2048
+THREADS_PER_BLOCK = 256
+SUPPORTED_DTYPES = (torch.bfloat16,)
+ABS_TOL = 1.25e-1
+REL_TOL = 4.0
+
+
+@dialect(
+    name="cuda",
+    compiler="clang",
+    file=CODE_DIR / "allreduce-device.cu",
+    extern_func_name="fused_allreduce_bf16",
+)
+def fused_allreduce_bf16(*args, **kwargs):
+    ...
+
+
+@triton.jit
+def residual_rmsnorm_kernel(
+    reduced_ptr,
+    residual_ptr,
+    weight_ptr,
+    norm_out_ptr,
+    eps,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    offs = tl.arange(0, BLOCK)
+    mask = offs < BLOCK
+    base = row * BLOCK + offs
+
+    reduced = tl.load(reduced_ptr + base, mask=mask, other=0.0).to(tl.float32)
+    residual = tl.load(residual_ptr + base, mask=mask, other=0.0).to(tl.float32)
+    z = reduced + residual
+
+    tl.store(reduced_ptr + base, z, mask=mask)
+
+    mean_square = tl.sum(z * z, axis=0) / BLOCK
+    rstd = tl.rsqrt(mean_square + eps)
+    weight = tl.load(weight_ptr + offs, mask=mask, other=0.0).to(tl.float32)
+    tl.store(norm_out_ptr + base, z * rstd * weight, mask=mask)
+
+
+@triton.jit(do_not_specialize=["rank", "world_size", "num_tokens"])
+def fused_allreduce_kernel(
+    reduced_ptr,
+    input_ptrs,
+    rank,
+    world_size,
+    num_tokens,
+):
+    tle_raw.call(
+        fused_allreduce_bf16,
+        [reduced_ptr, input_ptrs, rank, world_size, num_tokens],
+        output_indices=[0],
+    )
+
+
+def _round_up(value: int, multiple: int) -> int:
+    return ((int(value) + int(multiple) - 1) // int(multiple)) * int(multiple)
+
+
+def _seeded_batch(device: torch.device, tokens: int, rank: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    generator = torch.Generator(device=device)
+    generator.manual_seed(20260904 + tokens * 1009 + rank * 10007)
+    x = torch.randn(tokens, HIDDEN_SIZE, dtype=torch.bfloat16, device=device, generator=generator)
+    residual = torch.randn(tokens, HIDDEN_SIZE, dtype=torch.bfloat16, device=device, generator=generator)
+    weight = torch.randn(HIDDEN_SIZE, dtype=torch.bfloat16, device=device, generator=generator)
+    return x, residual, weight
+
+
+def _configure_host(host) -> None:
+    host.tle_ar_rmsnorm_workspace_create.argtypes = [
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.POINTER(ctypes.c_int),
+        ctypes.POINTER(ctypes.c_int),
+        ctypes.POINTER(ctypes.c_int),
+        ctypes.POINTER(ctypes.c_int),
+    ]
+    host.tle_ar_rmsnorm_workspace_create.restype = ctypes.c_int
+
+    host.tle_ar_rmsnorm_peer_workspace_ptr.argtypes = [ctypes.c_void_p, ctypes.c_int]
+    host.tle_ar_rmsnorm_peer_workspace_ptr.restype = ctypes.c_void_p
+    host.tle_ar_rmsnorm_sync_ready.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_uint64,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_void_p,
+    ]
+    host.tle_ar_rmsnorm_sync_ready.restype = ctypes.c_int
+    host.tle_ar_rmsnorm_workspace_destroy.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+    ]
+    host.tle_ar_rmsnorm_workspace_destroy.restype = ctypes.c_int
+
+
+@dataclass
+class _Runtime:
+    host: Any
+    common: Any
+    group: Any
+
+
+class FusedAllReduceResidualRMSNorm:
+    def __init__(self, max_tokens: int, group=None) -> None:
+        if not dist.is_initialized():
+            raise RuntimeError("torch.distributed must be initialized first")
+        if max_tokens <= 0:
+            raise ValueError("max_tokens must be positive")
+
+        self.group = group if group is not None else dist.group.WORLD
+        self.rank = dist.get_rank(self.group)
+        self.world_size = dist.get_world_size(self.group)
+        self.local_rank = int(os.environ.get("LOCAL_RANK", self.rank))
+        torch.cuda.set_device(self.local_rank)
+        self.device = torch.device("cuda", self.local_rank)
+
+        self.max_tokens = int(_round_up(max_tokens, 1))
+        self._closed = False
+        self._epoch = 0
+
+        self.runtime = self._load_runtime()
+        self._create_workspace()
+
+    def _load_runtime(self) -> _Runtime:
+        host = load_host(CODE_DIR / "allreduce-host.cu")
+        _configure_host(host)
+        common = load_common_host()
+        init_nvshmem_by_torch_pg(common, self.group)
+        return _Runtime(host=host, common=common, group=self.group)
+
+    def _create_workspace(self) -> None:
+        input_ptr = ctypes.c_void_p()
+        ready_ptr = ctypes.c_void_p()
+        stream_ptr = ctypes.c_void_p()
+        rank = ctypes.c_int()
+        world = ctypes.c_int()
+        local_rank = ctypes.c_int()
+        local_world = ctypes.c_int()
+
+        rc = self.runtime.host.tle_ar_rmsnorm_workspace_create(
+            self.max_tokens,
+            HIDDEN_SIZE,
+            ctypes.byref(input_ptr),
+            ctypes.byref(ready_ptr),
+            ctypes.byref(stream_ptr),
+            ctypes.byref(rank),
+            ctypes.byref(world),
+            ctypes.byref(local_rank),
+            ctypes.byref(local_world),
+        )
+        if rc != 0:
+            raise RuntimeError(f"tle_ar_rmsnorm_workspace_create failed: {rc}")
+
+        if rank.value != self.rank or world.value != self.world_size:
+            raise RuntimeError(
+                "NVSHMEM/Torch rank mismatch: "
+                f"nvshmem={rank.value}/{world.value} torch={self.rank}/{self.world_size}"
+            )
+        if world.value != local_world.value:
+            raise RuntimeError("tutorial supports one node only")
+
+        self.input_ptr = input_ptr
+        self.ready_ptr = ready_ptr
+        self.stream_ptr = stream_ptr
+        self.comm_stream = torch.cuda.ExternalStream(stream_ptr.value, device=self.device)
+        self.input_workspace = tensor_from_pointer(
+            input_ptr, (self.max_tokens, HIDDEN_SIZE), torch.bfloat16, self.device
+        )
+        self.reduced_workspace = torch.empty(
+            (self.max_tokens, HIDDEN_SIZE), dtype=torch.bfloat16, device=self.device
+        )
+        self.norm_workspace = torch.empty_like(self.reduced_workspace)
+
+        input_ptrs = []
+        for peer in range(self.world_size):
+            input_ptrs.append(
+                int(self.runtime.host.tle_ar_rmsnorm_peer_workspace_ptr(self.input_ptr, peer))
+            )
+
+        self.input_ptrs = torch.tensor(input_ptrs, dtype=torch.int64, device=self.device)
+
+    def _next_epoch(self) -> int:
+        self._epoch += 1
+        return self._epoch
+
+    def _validate(self, x: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor) -> int:
+        if self._closed:
+            raise RuntimeError("operator is closed")
+        if x.device != self.device or residual.device != self.device or weight.device != self.device:
+            raise ValueError("all tensors must be on the local CUDA device")
+        if x.dtype not in SUPPORTED_DTYPES or residual.dtype not in SUPPORTED_DTYPES or weight.dtype not in SUPPORTED_DTYPES:
+            raise ValueError("tutorial supports bfloat16 only")
+        if not x.is_contiguous() or not residual.is_contiguous() or not weight.is_contiguous():
+            raise ValueError("all tensors must be contiguous")
+        if x.ndim != 2 or x.shape[1] != HIDDEN_SIZE:
+            raise ValueError(f"input must have shape (tokens, {HIDDEN_SIZE})")
+        if residual.shape != x.shape:
+            raise ValueError("residual must match input shape")
+        if weight.ndim != 1 or weight.shape[0] != HIDDEN_SIZE:
+            raise ValueError(f"weight must have shape ({HIDDEN_SIZE},)")
+        if x.shape[0] > self.max_tokens:
+            raise ValueError("input exceeds configured capacity")
+        return int(x.shape[0])
+
+    def _validate_epilogue(
+        self, tokens: int, residual: torch.Tensor, weight: torch.Tensor
+    ) -> None:
+        if residual.device != self.device or weight.device != self.device:
+            raise ValueError("epilogue tensors must be on the local CUDA device")
+        if residual.dtype not in SUPPORTED_DTYPES or weight.dtype not in SUPPORTED_DTYPES:
+            raise ValueError("tutorial supports bfloat16 only")
+        if not residual.is_contiguous() or not weight.is_contiguous():
+            raise ValueError("epilogue tensors must be contiguous")
+        if residual.shape != (tokens, HIDDEN_SIZE):
+            raise ValueError("residual shape mismatch")
+        if weight.shape != (HIDDEN_SIZE,):
+            raise ValueError("weight shape mismatch")
+
+    def _validate_input_only(self, x: torch.Tensor) -> int:
+        if x.device != self.device:
+            raise ValueError(f"input must be on {self.device}, got {x.device}")
+        if x.dtype not in SUPPORTED_DTYPES:
+            raise ValueError("tutorial supports bfloat16 only")
+        if not x.is_contiguous():
+            raise ValueError("input must be contiguous")
+        if x.ndim != 2 or x.shape[1] != HIDDEN_SIZE:
+            raise ValueError(f"input must have shape (tokens, {HIDDEN_SIZE})")
+        if x.shape[0] > self.max_tokens:
+            raise ValueError("input exceeds configured capacity")
+        return int(x.shape[0])
+
+    def prepare_input(self, x: torch.Tensor) -> int:
+        tokens = self._validate_input_only(x)
+        self.input_workspace[:tokens].copy_(x, non_blocking=True)
+        return tokens
+
+    def run_prepared(
+        self,
+        tokens: int,
+        residual: torch.Tensor,
+        weight: torch.Tensor,
+        eps: float = 1e-6,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        self._validate_epilogue(tokens, residual, weight)
+
+        current_stream = torch.cuda.current_stream(self.device)
+        self.comm_stream.wait_stream(current_stream)
+        epoch = self._next_epoch()
+        rc = self.runtime.host.tle_ar_rmsnorm_sync_ready(
+            self.ready_ptr,
+            ctypes.c_uint64(epoch),
+            self.rank,
+            self.world_size,
+            self.stream_ptr,
+        )
+        if rc != 0:
+            raise RuntimeError(f"tle_ar_rmsnorm_sync_ready failed: {rc}")
+
+        with torch.cuda.stream(self.comm_stream):
+            fused_allreduce_kernel[(1,)](
+                self.reduced_workspace,
+                self.input_ptrs,
+                self.rank,
+                self.world_size,
+                tokens,
+                num_warps=THREADS_PER_BLOCK // 32,
+            )
+            residual_rmsnorm_kernel[(tokens,)](
+                self.reduced_workspace,
+                residual,
+                weight,
+                self.norm_workspace,
+                float(eps),
+                BLOCK=HIDDEN_SIZE,
+                num_warps=THREADS_PER_BLOCK // 32,
+            )
+
+        current_stream.wait_stream(self.comm_stream)
+        return self.reduced_workspace[:tokens], self.norm_workspace[:tokens]
+
+    def forward(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        weight: torch.Tensor,
+        eps: float = 1e-6,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        tokens = self.prepare_input(x)
+        return self.run_prepared(tokens, residual, weight, eps=eps)
+
+    def reference(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        weight: torch.Tensor,
+        eps: float = 1e-6,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        self._validate(x, residual, weight)
+        ref = x.to(torch.float32).clone()
+        dist.all_reduce(ref, op=dist.ReduceOp.SUM, group=self.group)
+        ref = ref + residual.to(torch.float32)
+        rstd = torch.rsqrt(ref.pow(2).mean(dim=-1, keepdim=True) + float(eps))
+        norm = ref * rstd * weight.to(torch.float32)
+        return ref.to(torch.bfloat16), norm.to(torch.bfloat16)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self.comm_stream.synchronize()
+        rc = self.runtime.host.tle_ar_rmsnorm_workspace_destroy(
+            self.input_ptr, self.ready_ptr, self.stream_ptr
+        )
+        if rc != 0:
+            raise RuntimeError(f"tle_ar_rmsnorm_workspace_destroy failed: {rc}")
+        finalize = getattr(self.runtime.common, "nvshmem_finalize_from_torch_distributed", None)
+        if finalize is not None:
+            finalize_rc = finalize()
+            if finalize_rc != 0:
+                raise RuntimeError(
+                    f"nvshmem_finalize_from_torch_distributed failed: {finalize_rc}"
+                )
+        self._closed = True
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="NVSHMEM fused AllReduce + Residual + RMSNorm tutorial")
+    parser.add_argument("--tokens", type=int, nargs="+", default=[1, 16, 64, 128, 256, 1024, 4096])
+    parser.add_argument("--dtype", choices=("bfloat16",), default="bfloat16")
+    parser.add_argument("--eps", type=float, default=1.0e-6)
+    return parser.parse_args()
+
+
+def run_correctness(tokens_list: list[int], eps: float) -> None:
+    group = init_torch_distributed()
+    rank = dist.get_rank(group)
+
+    operator = FusedAllReduceResidualRMSNorm(max(tokens_list), group=group)
+    try:
+        if rank == 0:
+            print(
+                f"world_size={operator.world_size} hidden={HIDDEN_SIZE} dtype=bfloat16",
+                flush=True,
+            )
+
+        for tokens in tokens_list:
+            x, residual, weight = _seeded_batch(operator.device, tokens, rank)
+            reduced, norm = operator.forward(x, residual, weight, eps=eps)
+            dist.barrier(group=operator.group)
+            ref_reduced, ref_norm = operator.reference(x, residual, weight, eps=eps)
+            abs_reduced = (reduced - ref_reduced).abs().max().item()
+            abs_norm = (norm - ref_norm).abs().max().item()
+            rel_reduced = (
+                (reduced - ref_reduced).abs()
+                / torch.maximum(
+                    ref_reduced.abs(),
+                    torch.tensor(1e-2, device=operator.device, dtype=ref_reduced.dtype),
+                )
+            ).max().item()
+            rel_norm = (
+                (norm - ref_norm).abs()
+                / torch.maximum(
+                    ref_norm.abs(),
+                    torch.tensor(1e-2, device=operator.device, dtype=ref_norm.dtype),
+                )
+            ).max().item()
+            max_abs = max(abs_reduced, abs_norm)
+            max_rel = max(rel_reduced, rel_norm)
+            ok = max_abs <= ABS_TOL
+            if rank == 0:
+                print(
+                    f"tokens={tokens} max_abs={max_abs:.6f} max_rel={max_rel:.6f} "
+                    f"status={'PASS' if ok else 'FAIL'}",
+                    flush=True,
+                )
+            if not ok:
+                raise RuntimeError(f"correctness failed for tokens={tokens}")
+    finally:
+        operator.close()
+        dist.destroy_process_group(group)
+        dist.destroy_process_group()
+
+
+def main() -> None:
+    args = parse_args()
+    run_correctness(args.tokens, args.eps)
+
+
+if __name__ == "__main__":
+    main()

--- a/python/tutorials/tle/raw/nvshmem/05-allreduce-rmsnorm/benchmark.py
+++ b/python/tutorials/tle/raw/nvshmem/05-allreduce-rmsnorm/benchmark.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+# Copyright 2026, The FlagOS Contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import statistics
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.distributed as dist
+
+from triton.experimental.tle.raw.nvshmem.utils import init_torch_distributed
+
+CODE_DIR = Path(__file__).parent.resolve()
+DEFAULT_TOKENS = [1, 16, 64, 128, 256, 1024, 4096]
+WARMUP = 200
+MEASURE_ITERS = 1000
+FRESH_REPS = 5
+ABS_TOL = 1.25e-1
+REL_TOL = 4.0
+
+
+def _load_module():
+    path = CODE_DIR / "allreduce.py"
+    spec = importlib.util.spec_from_file_location("_tle_ar_rmsnorm", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load module from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MODULE = _load_module()
+Operator = MODULE.FusedAllReduceResidualRMSNorm
+HIDDEN_SIZE = MODULE.HIDDEN_SIZE
+
+try:
+    import flashinfer.comm as flashinfer_comm  # type: ignore
+
+    if not hasattr(flashinfer_comm, "trtllm_allreduce_fusion"):
+        flashinfer_comm = None
+except Exception:
+    flashinfer_comm = None
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Benchmark NVSHMEM fused AllReduce + Residual + RMSNorm")
+    parser.add_argument("--tokens", type=int, nargs="+", default=DEFAULT_TOKENS)
+    parser.add_argument("--output-json", type=Path, required=True)
+    return parser.parse_args()
+
+
+def _percentile(values: list[float], q: float) -> float:
+    if not values:
+        return float("nan")
+    ordered = sorted(values)
+    idx = int(round((len(ordered) - 1) * q))
+    return ordered[idx]
+
+
+def _timed_loop(fn, iters: int, device: torch.device) -> list[float]:
+    samples: list[float] = []
+    for _ in range(iters):
+        start = time.perf_counter()
+        fn()
+        torch.cuda.synchronize(device)
+        samples.append((time.perf_counter() - start) * 1000.0)
+    return samples
+
+
+def _gather_samples(local: list[float], group) -> list[list[float]]:
+    gathered: list[list[float] | None] = [None] * dist.get_world_size(group)
+    dist.all_gather_object(gathered, local, group=group)
+    return [entry or [] for entry in gathered]
+
+
+def _max_across_ranks(per_rank: list[list[float]]) -> list[float]:
+    if not per_rank:
+        return []
+    length = len(per_rank[0])
+    return [max(rank_values[i] for rank_values in per_rank) for i in range(length)]
+
+
+def _summarize_repetitions(repetition_samples: list[list[float]]) -> dict[str, float]:
+    pooled = [sample for rep in repetition_samples for sample in rep]
+    rep_p50s = [_percentile(rep, 0.5) for rep in repetition_samples if rep]
+    return {
+        "p50": _percentile(pooled, 0.5),
+        "p90": _percentile(pooled, 0.9),
+        "p99": _percentile(pooled, 0.99),
+        "repeat_p50_mean": statistics.mean(rep_p50s) if rep_p50s else float("nan"),
+        "repeat_p50_std": statistics.pstdev(rep_p50s) if len(rep_p50s) > 1 else 0.0,
+    }
+
+
+def _seeded_batch(device: torch.device, tokens: int, rank: int, rep: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    generator = torch.Generator(device=device)
+    generator.manual_seed(20260904 + tokens * 1009 + rank * 10007 + rep * 97)
+    x = torch.randn(tokens, HIDDEN_SIZE, dtype=torch.bfloat16, device=device, generator=generator)
+    residual = torch.randn(tokens, HIDDEN_SIZE, dtype=torch.bfloat16, device=device, generator=generator)
+    weight = torch.randn(HIDDEN_SIZE, dtype=torch.bfloat16, device=device, generator=generator)
+    return x, residual, weight
+
+
+class FlashInferBaseline:
+    def __init__(self, op: Operator, group) -> None:
+        self.available = False
+        self.reason = "flashinfer.comm is unavailable"
+        self.group = group
+        self.rank = op.rank
+        self.world_size = op.world_size
+        self.device = op.device
+        self._ipc_handles: Any = None
+        self.workspace = None
+        self.input = None
+        self.residual_out = None
+        self.norm_out = None
+
+        if flashinfer_comm is None:
+            return
+
+        create_fn = getattr(
+            flashinfer_comm,
+            "trtllm_create_ipc_workspace_for_all_reduce_fusion",
+            None,
+        )
+        if create_fn is None:
+            self.reason = "flashinfer.comm missing trtllm_create_ipc_workspace_for_all_reduce_fusion"
+            return
+
+        kwargs = dict(
+            tp_rank=self.rank,
+            tp_size=self.world_size,
+            max_token_num=op.max_tokens,
+            hidden_dim=HIDDEN_SIZE,
+            group=group,
+            use_fp32_lamport=False,
+        )
+        try:
+            self._ipc_handles, self.workspace = create_fn(**kwargs)
+        except TypeError:
+            kwargs.pop("group")
+            self._ipc_handles, self.workspace = create_fn(**kwargs)
+        except Exception as exc:
+            self.reason = f"flashinfer workspace init failed: {exc}"
+            return
+
+        self.input = torch.empty((op.max_tokens, HIDDEN_SIZE), dtype=torch.bfloat16, device=self.device)
+        self.residual_out = torch.empty_like(self.input)
+        self.norm_out = torch.empty_like(self.input)
+        self.available = True
+        self.reason = ""
+
+    def close(self) -> None:
+        if not self.available or self._ipc_handles is None:
+            return
+        destroy_fn = getattr(
+            flashinfer_comm,
+            "trtllm_destroy_ipc_workspace_for_all_reduce",
+            None,
+        )
+        if destroy_fn is None:
+            return
+        destroy_fn(self._ipc_handles, self.group)
+
+    def prepare_input(self, x: torch.Tensor) -> None:
+        if not self.available:
+            raise RuntimeError(self.reason)
+        self.input[: x.shape[0]].copy_(x, non_blocking=True)
+
+    def run_prepared(self, tokens: int, residual: torch.Tensor, weight: torch.Tensor, eps: float) -> None:
+        if not self.available:
+            raise RuntimeError(self.reason)
+        kwargs = dict(
+            allreduce_in=self.input[:tokens],
+            token_num=tokens,
+            residual_in=residual,
+            residual_out=self.residual_out[:tokens],
+            norm_out=self.norm_out[:tokens],
+            rms_gamma=weight,
+            rms_eps=float(eps),
+            hidden_dim=HIDDEN_SIZE,
+            workspace_ptrs=self.workspace,
+            pattern_code=flashinfer_comm.AllReduceFusionPattern.kARResidualRMSNorm,
+            allreduce_out=None,
+            quant_out=None,
+            scale_out=None,
+            layout_code=None,
+            scale_factor=None,
+            use_oneshot=True,
+            world_rank=self.rank,
+            world_size=self.world_size,
+            launch_with_pdl=True,
+            trigger_completion_at_end=True,
+            fp32_acc=True,
+        )
+        flashinfer_comm.trtllm_allreduce_fusion(**kwargs)
+
+    def stage_inclusive_step(self, x: torch.Tensor, residual: torch.Tensor, weight: torch.Tensor, eps: float) -> None:
+        self.input[: x.shape[0]].copy_(x, non_blocking=True)
+        self.run_prepared(x.shape[0], residual, weight, eps)
+
+
+def _check_correctness(
+    op: Operator,
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    eps: float,
+) -> tuple[float, float]:
+    reduced, norm = op.forward(x, residual, weight, eps=eps)
+    dist.barrier(group=op.group)
+    ref_reduced, ref_norm = op.reference(x, residual, weight, eps=eps)
+    abs_reduced = (reduced - ref_reduced).abs().max().item()
+    abs_norm = (norm - ref_norm).abs().max().item()
+    rel_reduced = (
+        (reduced - ref_reduced).abs()
+        / torch.maximum(
+            ref_reduced.abs(),
+            torch.tensor(1e-2, device=op.device, dtype=ref_reduced.dtype),
+        )
+    ).max().item()
+    rel_norm = (
+        (norm - ref_norm).abs()
+        / torch.maximum(
+            ref_norm.abs(),
+            torch.tensor(1e-2, device=op.device, dtype=ref_norm.dtype),
+        )
+    ).max().item()
+    return max(abs_reduced, abs_norm), max(rel_reduced, rel_norm)
+
+
+def _benchmark_variant(
+    op: Operator,
+    batch_factory,
+    warmup_fn,
+    timed_fn,
+    tokens: int,
+    eps: float,
+    warmup: int,
+    iters: int,
+    reps: int,
+) -> dict[str, float]:
+    repetition_samples: list[list[float]] = []
+    for rep in range(reps):
+        x, residual, weight = batch_factory(rep)
+        for _ in range(warmup):
+            warmup_fn(x, residual, weight, eps)
+        torch.cuda.synchronize(op.device)
+        dist.barrier(group=op.group)
+        local = _timed_loop(lambda: timed_fn(x, residual, weight, eps), iters, op.device)
+        max_series = _max_across_ranks(_gather_samples(local, op.group))
+        repetition_samples.append(max_series)
+        dist.barrier(group=op.group)
+    return _summarize_repetitions(repetition_samples)
+
+
+def _benchmark_tokens(op: Operator, tokens: int, baseline: FlashInferBaseline, rank: int) -> dict[str, Any]:
+    candidate = {
+        "prepared": {"status": "skipped"},
+        "stage_inclusive": {"status": "skipped"},
+    }
+    flashinfer = {
+        "prepared": {"status": "unavailable", "reason": baseline.reason},
+        "stage_inclusive": {"status": "unavailable", "reason": baseline.reason},
+    }
+
+    def batch_factory(rep: int) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        return _seeded_batch(op.device, tokens, rank, rep)
+
+    for rep in range(FRESH_REPS):
+        x, residual, weight = batch_factory(rep)
+        max_abs, max_rel = _check_correctness(op, x, residual, weight, 1.0e-6)
+        if rank == 0:
+            status = "PASS" if max_abs <= ABS_TOL and max_rel <= REL_TOL else "FAIL"
+            print(
+                f"tokens={tokens} max_abs={max_abs:.6f} max_rel={max_rel:.6f} status={status}",
+                flush=True,
+            )
+        if max_abs > ABS_TOL:
+            raise RuntimeError(f"correctness failed for tokens={tokens}")
+
+    def candidate_prepare(x, residual, weight, eps):
+        op.prepare_input(x)
+
+    def candidate_prepared(_, residual, weight, eps):
+        op.run_prepared(tokens, residual, weight, eps=eps)
+
+    def candidate_stage(x, residual, weight, eps):
+        op.forward(x, residual, weight, eps=eps)
+
+    candidate["prepared"] = _benchmark_variant(
+        op,
+        batch_factory,
+        candidate_prepare,
+        candidate_prepared,
+        tokens,
+        1.0e-6,
+        WARMUP,
+        MEASURE_ITERS,
+        FRESH_REPS,
+    )
+    candidate["stage_inclusive"] = _benchmark_variant(
+        op,
+        batch_factory,
+        candidate_stage,
+        candidate_stage,
+        tokens,
+        1.0e-6,
+        WARMUP,
+        MEASURE_ITERS,
+        FRESH_REPS,
+    )
+
+    if baseline.available:
+        def baseline_prepare(x, residual, weight, eps):
+            baseline.prepare_input(x)
+
+        def baseline_prepared(_, residual, weight, eps):
+            baseline.run_prepared(tokens, residual, weight, eps)
+
+        def baseline_stage(x, residual, weight, eps):
+            baseline.stage_inclusive_step(x, residual, weight, eps)
+
+        flashinfer["prepared"] = _benchmark_variant(
+            op,
+            batch_factory,
+            baseline_prepare,
+            baseline_prepared,
+            tokens,
+            1.0e-6,
+            WARMUP,
+            MEASURE_ITERS,
+            FRESH_REPS,
+        )
+        flashinfer["stage_inclusive"] = _benchmark_variant(
+            op,
+            batch_factory,
+            baseline_stage,
+            baseline_stage,
+            tokens,
+            1.0e-6,
+            WARMUP,
+            MEASURE_ITERS,
+            FRESH_REPS,
+        )
+
+    return {"candidate": candidate, "flashinfer": flashinfer}
+
+
+def main() -> None:
+    args = parse_args()
+    group = init_torch_distributed()
+    rank = dist.get_rank(group)
+
+    op = Operator(max(args.tokens), group=group)
+    baseline = FlashInferBaseline(op, group)
+    try:
+        results: dict[str, Any] = {
+            "world_size": op.world_size,
+            "hidden_size": HIDDEN_SIZE,
+            "warmup": WARMUP,
+            "measurement_iterations": MEASURE_ITERS,
+            "fresh_repetitions": FRESH_REPS,
+            "timing_definition": "max latency across ranks, wall-clock milliseconds per iteration",
+            "results": {},
+        }
+        for tokens in args.tokens:
+            if rank == 0:
+                print(f"benchmarking tokens={tokens}", flush=True)
+            results["results"][str(tokens)] = _benchmark_tokens(op, tokens, baseline, rank)
+        if rank == 0:
+            args.output_json.parent.mkdir(parents=True, exist_ok=True)
+            args.output_json.write_text(json.dumps(results, indent=2), encoding="utf-8")
+            print(f"Results saved to {args.output_json}", flush=True)
+    finally:
+        baseline.close()
+        op.close()
+        dist.destroy_process_group(group)
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<html><head></head><body><h2>Summary</h2><p>This PR adds a TLE-Raw NVSHMEM tutorial for a fused distributed operator with the following contract:</p><pre><code class="language-text">reduced      = AllReduce_SUM(x)
residual_out = reduced + residual
norm_out     = RMSNorm(residual_out, weight, eps)
</code></pre><p>The tutorial demonstrates how to integrate a CUDA/NVSHMEM device-side collective into FlagTree through TLE-Raw, followed by a Triton residual + RMSNorm epilogue.</p><p>The implementation is added under:</p><pre><code class="language-text">python/tutorials/tle/raw/nvshmem/05-allreduce-rmsnorm/
├── allreduce-device.cu
├── allreduce-host.cu
├── allreduce.py
└── benchmark.py
</code></pre><h2>Motivation</h2><p>The existing NVSHMEM TLE-Raw tutorials demonstrate lower-level communication primitives such as CUDA-IPC AllReduce.</p><p>This tutorial extends that path to a representative LLM distributed fusion pattern:</p><pre><code class="language-text">tensor-parallel AllReduce
        ↓
residual add
        ↓
RMSNorm
</code></pre><p>The goal is to provide a compact example showing how TLE-Raw can be used to combine:</p><ul><li><p>CUDA/NVSHMEM device functions,</p></li><li><p>symmetric communication workspace,</p></li><li><p>distributed synchronization,</p></li><li><p>Triton-side tensor computation,</p></li><li><p>correctness validation, and</p></li><li><p>reproducible operator benchmarking.</p></li></ul><p>This PR is intended as a TLE-Raw integration and optimization example rather than as a universal replacement for an existing production collective implementation.</p><h2>Implementation</h2><h3>1. TLE-Raw NVSHMEM AllReduce</h3><p><code inline="">allreduce-device.cu</code> implements the device-side BF16 collective path used by the tutorial.</p><p>The native CUDA functions are registered from Python through the current TLE-Raw <code inline="">@dialect(...)</code> interface and invoked from the Triton path with <code inline="">tle_raw.call(...)</code>.</p><p>The implementation uses rank-visible communication buffers and explicit synchronization required by the NVSHMEM communication path.</p><h3>2. Row-parallel execution</h3><p>The collective stage maps token rows to independent CTAs.</p><p>Instead of serializing multiple token rows through one CTA, the implementation uses approximately:</p><pre><code class="language-text">one CTA per token row
</code></pre><p>so the available parallelism scales with the token dimension.</p><p>This is especially important when moving from decode-sized inputs to larger token counts.</p><h3>3. Residual + RMSNorm epilogue</h3><p>After the distributed reduction completes, the epilogue computes:</p><pre><code class="language-text">residual_out = reduced + residual
norm_out     = RMSNorm(residual_out, weight, eps)
</code></pre><p>with FP32 accumulation where required for normalization.</p><h3>4. Host-side NVSHMEM lifecycle</h3><p><code inline="">allreduce-host.cu</code> contains the host/runtime integration required by the tutorial, including:</p><ul><li><p>NVSHMEM initialization,</p></li><li><p>distributed bootstrap,</p></li><li><p>symmetric workspace management,</p></li><li><p>host-side C ABI, and</p></li><li><p>resource cleanup.</p></li></ul><h3>5. Python API and correctness test</h3><p><code inline="">allreduce.py</code> provides:</p><ul><li><p>TLE-Raw CUDA function registration,</p></li><li><p>the reusable operator/communicator wrapper,</p></li><li><p>distributed initialization,</p></li><li><p>a PyTorch reference implementation, and</p></li><li><p>standalone correctness validation through <code inline="">torchrun</code>.</p></li></ul><h3>6. Benchmark harness</h3><p><code inline="">benchmark.py</code> provides a standalone distributed benchmark with:</p><ul><li><p>configurable token shapes,</p></li><li><p>warmup iterations,</p></li><li><p>repeated timing,</p></li><li><p>per-rank synchronization,</p></li><li><p>rank-max latency aggregation,</p></li><li><p>percentile statistics, and</p></li><li><p>JSON result output.</p></li></ul><p>The benchmark implementation reuses the operator from <code inline="">allreduce.py</code> rather than maintaining a second implementation.</p><h2>Correctness</h2><p>Validated on NVIDIA H20 GPUs with:</p><pre><code class="language-text">world size: 4
hidden size: 2048
dtype: BF16
</code></pre><p>Token counts:</p>
Tokens | Max absolute error | Status
-- | -- | --
1 | 0.03125 | PASS
16 | 0.03125 | PASS
64 | 0.06250 | PASS
128 | 0.06250 | PASS
256 | 0.06250 | PASS
1024 | 0.06250 | PASS
4096 | 0.06250 | PASS

<p>In these serving workloads, the current NVSHMEM route remains behind the mature FlashInfer production path, corresponding to roughly a 12–15% decode-throughput gap.</p><p>This framework result is included as an engineering boundary rather than as a performance-win claim. The tutorial contribution itself focuses on making the TLE-Raw NVSHMEM fusion path correct, reusable, and reproducibly benchmarkable.</p><h2>Files changed</h2><p>Only the new tutorial directory is added:</p><pre><code class="language-text">python/tutorials/tle/raw/nvshmem/05-allreduce-rmsnorm/
</code></pre><p>with four source files:</p><ul><li><p><code inline="">allreduce-device.cu</code></p></li><li><p><code inline="">allreduce-host.cu</code></p></li><li><p><code inline="">allreduce.py</code></p></li><li><p><code inline="">benchmark.py</code></p></li></ul><p>No framework-specific integration code, generated benchmark artifacts, or machine-specific paths are included in the PR.</p><h2>Validation</h2><p>Local validation performed:</p><ul class="contains-task-list"><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> TLE-Raw import/runtime validation</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> NVSHMEM distributed correctness</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> TP4 / H2048 / BF16 correctness across T=1...4096</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> standalone benchmark execution</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> <code inline="">git diff --check</code></p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> copyright notice audit</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> third-party source provenance audit</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> no generated benchmark/profile artifacts included</p></li><li class="task-list-item"><p><input type="checkbox" checked="" disabled=""> no machine-specific absolute paths included</p></li></ul><p>Repository CI is expected to provide the final formatting/build validation.</p><h2>License / copyright</h2><p>All newly added source files contain the FlagOS copyright notice.</p><p>The final tutorial code was written against the current FlagTree TLE-Raw APIs. No GPL/LGPL/AGPL-derived implementation code or third-party source text is included in the added files.</p></body></html>