### PR TITLE
[TLE][Ascend][XCS][FEAT] Add enable-legacy-insert-load-store-for-mix-cv kernel lau…

### DIFF
--- a/python/triton/experimental/tle/language/dsa/ascend/custom_ops/CUSTOM_OP_USAGE.md
+++ b/python/triton/experimental/tle/language/dsa/ascend/custom_ops/CUSTOM_OP_USAGE.md
@@ -83,9 +83,9 @@ tile_k = tle.dsa.ascend.raw(
 
 相邻索引（`index[i + 1] == index[i] + 1`）会合并为一次两行搬运。
 
-> **重要**：调用本算子的 kernel 必须传编译选项 `disable_auto_cv_work_space_manage=True`。CANN 9.1.0（bishengir 1.2.0 正式版）重构了 `InsertLoadStoreForMixCV`，重构版对 custom op 的 memscope / coreType 推断仍有 bug：PIPE_MTE2 custom op 的 out 会被规划到 GM workspace（并误插 cbuf→cbuf load），与本算子 `__cbuf__` 的 C++ ABI 冲突。
+> **重要**：调用本算子的 kernel 必须传编译选项 `enable_legacy_insert_load_store_for_mix_cv=True`（kernel launch kwarg，后端转发为 bishengir-compile 的 `--enable-legacy-insert-load-store-for-mix-cv`，把 `InsertLoadStoreForMixCV` 整个 pass 回退到重构前的老版本）。CANN 9.1.0（bishengir 1.2.0 正式版）重构了 `InsertLoadStoreForMixCV`，重构版对 custom op 的 memscope / coreType 推断仍有 bug：PIPE_MTE2 custom op 的 out 会被规划到 GM workspace（并误插 cbuf→cbuf load），与本算子 `__cbuf__` 的 C++ ABI 冲突；回退到老版本 pass 即可绕开。
 >
-> **TODO**：`disable_auto_cv_work_space_manage=True` 只是临时规避（per-kernel 关闭 mix-CV workspace 管理，会连带关闭 multi-buffer / CV 流水线）。等 bishengir 修复重构版 `InsertLoadStoreForMixCV` 对 custom op 的推断 bug，或后端编译选项加上 `-enable-legacy-insert-load-store-for-mix-cv`（整个 pass 回退到重构前的老版本）后，去掉该 kwarg。
+> **TODO**：用 `enable_legacy_insert_load_store_for_mix_cv=True`，目前用该option规避。等 bishengir 修复重构版 `InsertLoadStoreForMixCV` 对 custom op 的推断 bug 后，可去掉该 kwarg。
 
 完整示例见 `python/tutorials/tle/custom/test_custom_ops.py`（`test_gather_gm_to_l1`）。
 
@@ -104,9 +104,9 @@ tile_v = tle.dsa.ascend.raw(
 
 参数含义与 `gather_gm_to_l1` 相同，区别是结果写入二维 UB half/bf16 张量。输出第一维 stride 不得小于 `D`。
 
-> **重要**：与 `gather_gm_to_l1` 相同，调用本算子的 kernel 必须传 `disable_auto_cv_work_space_manage=True`（PIPE_MTE2 + `__ubuf__` ABI，原因同上）。
+> **重要**：与 `gather_gm_to_l1` 相同，调用本算子的 kernel 必须传 `enable_legacy_insert_load_store_for_mix_cv=True`（PIPE_MTE2 + `__ubuf__` ABI，原因同上）。
 >
-> **TODO**：去掉条件同 `gather_gm_to_l1`——等 `InsertLoadStoreForMixCV` 重构 bug 修复，或后端加上 `-enable-legacy-insert-load-store-for-mix-cv` 后，该 kwarg 可去掉。
+> **TODO**：去掉条件同 `gather_gm_to_l1`——等 `InsertLoadStoreForMixCV` 重构版对 custom op 的推断 bug 修复后，该 kwarg 可去掉。
 
 完整示例见 `python/tutorials/tle/custom/test_custom_ops.py`（`test_gather_gm_to_ub`）。
 

--- a/python/tutorials/tle/custom/test_custom_ops.py
+++ b/python/tutorials/tle/custom/test_custom_ops.py
@@ -258,7 +258,7 @@ def test_gather_gm_to_l1(torch_dtype, tol):
         TILE_SIZE=TILE_SIZE,
         D=D,
         DTYPE=_TL_DTYPE[torch_dtype],
-        disable_auto_cv_work_space_manage=True,
+        enable_legacy_insert_load_store_for_mix_cv=True,
     )
     torch_npu.npu.synchronize()
 
@@ -282,7 +282,7 @@ def test_gather_gm_to_ub(torch_dtype):
         TILE_SIZE=TILE_SIZE,
         D=D,
         DTYPE=_TL_DTYPE[torch_dtype],
-        disable_auto_cv_work_space_manage=True,
+        enable_legacy_insert_load_store_for_mix_cv=True,
     )
     torch_npu.npu.synchronize()
 

--- a/third_party/ascend/backend/compiler.py
+++ b/third_party/ascend/backend/compiler.py
@@ -540,6 +540,11 @@ def linalg_to_bin_enable_npu_compile_910_95(linalg: str, metadata, opt):
             _compile_option_list += \
                 [f"--disable-auto-cv-work-space-manage={disable_auto_cv_work_space_manage}"]
 
+        enable_legacy_insert_load_store_for_mix_cv = metadata.get("enable_legacy_insert_load_store_for_mix_cv")
+        if enable_legacy_insert_load_store_for_mix_cv is not None:
+            _compile_option_list += \
+                [f"--enable-legacy-insert-load-store-for-mix-cv={enable_legacy_insert_load_store_for_mix_cv}"]
+
         enable_tuning_mode = metadata.get("enable_tuning_mode")
         if enable_tuning_mode is not None:
             _compile_option_list += \
@@ -795,7 +800,10 @@ def linalg_to_bin_enable_npu_compile_A2_A3(linalg: str, metadata, opt):
         if disable_auto_cv_work_space_manage is not None:
             _compile_option_list += \
                 [f"--disable-auto-cv-work-space-manage={disable_auto_cv_work_space_manage}"]
-
+        enable_legacy_insert_load_store_for_mix_cv = metadata.get("enable_legacy_insert_load_store_for_mix_cv")
+        if enable_legacy_insert_load_store_for_mix_cv is not None:
+            _compile_option_list += \
+                [f"--enable-legacy-insert-load-store-for-mix-cv={enable_legacy_insert_load_store_for_mix_cv}"]
         enable_tuning_mode = metadata.get("enable_tuning_mode")
         if enable_tuning_mode is not None:
             _compile_option_list += \
@@ -910,6 +918,7 @@ class NPUOptions:
     enable_auto_bind_sub_block: bool = None
     disable_tightly_coupled_buffer_reuse: bool = False
     disable_auto_cv_work_space_manage: bool = None
+    enable_legacy_insert_load_store_for_mix_cv: bool = None
     enable_select_analysis: bool = True
     enable_hivm_auto_cv_balance: bool = None
     sync_solver: bool = None


### PR DESCRIPTION

Add an `enable_legacy_insert_load_store_for_mix_cv` field to NPUOptions so the flag can be passed as a per-kernel launch kwarg, and forward it to bishengir-compile as `--enable-legacy-insert-load-store-for-mix-cv` in both the 910_95 and A2/A3 paths, following the existing `disable_auto_cv_work_space_manage` pattern. The option rolls the `InsertLoadStoreForMixCV` pass back to its pre-refactor implementation, avoiding the refactored pass misinferring memscope/coreType for PIPE_MTE2 custom ops (out planned into GM workspace plus spurious cbuf-to-cbuf loads that conflict with the `__cbuf__`/`__ubuf__` C++ ABI).

Switch the gather_gm_to_l1 / gather_gm_to_ub examples in test_custom_ops.py from the `disable_auto_cv_work_space_manage=True` workaround to the new option, and update CUSTOM_OP_USAGE.md accordingly. The old kwarg disabled mix-CV workspace management wholesale (also disabling multi-buffering / CV pipelining), while the new one only rolls back this single pass. The kwarg can be dropped once bishengir fixes the custom-op inference bug in the refactored pass.

