### PR TITLE
[ENFLAME] fix gcc7 compile error in of namespace

### DIFF
--- a/third_party/tle/python/triton_tle_dsa.cc
+++ b/third_party/tle/python/triton_tle_dsa.cc
@@ -21,8 +21,6 @@
 namespace py = pybind11;
 using namespace mlir;
 
-namespace dsa = mlir::dsa;
-
 // Inject a three-operand dsa binary op builder: create_dsa_<name>(lhs, rhs,
 // out).
 template <typename DsaOpT>


### PR DESCRIPTION
gcc7 cannot resolve a namespace alias whose name equals the innermost
namespace component (namespace dsa = mlir::dsa;) when it is used as a
nested-name-specifier inside template arguments. 

Every dsa::X in a template argument list fails with "parse error in template argument
list" / "template argument 1 is invalid", including non-lambda sites
such as defBinaryOp<dsa::AddOp> and context.getOrLoadDialect<...>().
gcc9+ is not affected. The earlier template-keyword workaround