### PR TITLE
[CI] Simplify baseline path in compare-flaggems-test action

### DIFF
--- a/.github/actions/compare-flaggems-test/action.yml
+++ b/.github/actions/compare-flaggems-test/action.yml
@@ -67,14 +67,7 @@ runs:
       run: |
         set -x
 
-        # Determine baseline date
-        if [ -n "${{ inputs.baseline-date }}" ]; then
-          BASELINE_DATE="${{ inputs.baseline-date }}"
-        else
-          BASELINE_DATE=$(date +%Y-%m-%d)
-        fi
-
-        BASELINE_JSON="${{ inputs.baseline-dir }}/${BASELINE_DATE}/summary.json"
+        BASELINE_JSON="${{ inputs.baseline-dir }}/summary.json"
         CANDIDATE_JSON="${{ inputs.candidate-dir }}/summary.json"
 
         echo "Baseline: $BASELINE_JSON"


### PR DESCRIPTION
Remove the date-based baseline path construction. The baseline is now read directly from ${baseline-dir}/summary.json.

<!-- PR Title Format:
[TLE][BUILD][TEST][CI/CD][DOC][PROTON][BACKEND][FLIR] Brief description
[LANGUAGE][AUTOTUNER][LAYOUT][PIPELINE][WarpSpecialization] Brief description
Do not set the following title tags: [FEATURE][BUG][FixBug][Refine] ...
-->
