### PR TITLE
[XPU] Sample wrap tiles in OffsetAnalysis to fix a stride-0 view copy

### DIFF
--- a/third_party/xpu/lib/Dialect/TritonXPU/Transforms/OffsetAnalysis.cpp
+++ b/third_party/xpu/lib/Dialect/TritonXPU/Transforms/OffsetAnalysis.cpp
@@ -8,6 +8,8 @@
 #include "triton/Dialect/TritonXPU/IR/Dialect.h"
 #include "triton/Dialect/TritonXPU/Transforms/Passes.h"
 
+#include <limits>
+
 #define DEBUG_TYPE "tritonxpu-offset-analysis"
 
 namespace mlir {
@@ -33,6 +35,11 @@ public:
     this->dumpFlag = dumpFlag;
     this->bufferSize = bufferSize;
   }
+
+  // Program ids walked by the offset mock: the physical cluster count, plus a
+  // few tiles picked for the wraps that fall outside that dense range.
+  static constexpr int numMockProgramIds = 12;
+  static constexpr size_t maxExtraProgramIds = 4;
 
   struct MockData {
     Operation *mockOp;
@@ -207,10 +214,120 @@ public:
     }
   }
 
+  // Constant integer behind `v`, either a scalar or a splatted tensor. 0 when
+  // `v` is not a constant.
+  int64_t getConstIntVal(Value v) {
+    auto constOp = v.getDefiningOp<arith::ConstantOp>();
+    if (!constOp)
+      return 0;
+    if (auto splatAttr = dyn_cast<SplatElementsAttr>(constOp.getValue()))
+      return splatAttr.getSplatValue<APInt>().getSExtValue();
+    if (auto intAttr = dyn_cast<IntegerAttr>(constOp.getValue()))
+      return intAttr.getInt();
+    return 0;
+  }
+
+  // True when `v` is the program id itself, up to the casts that may wrap it.
+  // Deliberately not transitive: an index rebuilt from the program id (e.g.
+  // `(pid * tile + lane) / D`) is scaled by a stride of the tensor, not by the
+  // distance between two program ids.
+  bool isProgramId(Value v) {
+    Operation *op = v.getDefiningOp();
+    while (op && isa<arith::IndexCastOp, arith::ExtSIOp, arith::TruncIOp>(op))
+      op = op->getOperand(0).getDefiningOp();
+    return op && isa<triton::GetProgramIdOp>(op);
+  }
+
+  // Linear-index distance between two consecutive program ids: the constant the
+  // program id is scaled by in `pid * tile_size + tl.arange(0, tile_size)`, or
+  // the range width when that multiply is not a constant.
+  int64_t getProgramIdStride(const SetVector<Operation *> &opChain) {
+    int64_t rangeSpan = 0;
+    for (auto *op : opChain) {
+      if (auto rangeOp = dyn_cast<triton::MakeRangeOp>(op))
+        rangeSpan = std::max<int64_t>(rangeSpan,
+                                      rangeOp.getEnd() - rangeOp.getStart());
+    }
+    for (auto *op : opChain) {
+      auto mulOp = dyn_cast<arith::MulIOp>(op);
+      if (!mulOp)
+        continue;
+      int64_t scale = getConstIntVal(mulOp.getRhs());
+      Value scaled = mulOp.getLhs();
+      if (scale == 0) {
+        scale = getConstIntVal(mulOp.getLhs());
+        scaled = mulOp.getRhs();
+      }
+      if (scale > 0 && isProgramId(scaled))
+        return scale;
+    }
+    return rangeSpan;
+  }
+
+  // Linear-index positions where a multi-dimensional index reconstruction can
+  // break the offset sequence. `i = (idx / D) % C` holds still for D
+  // consecutive indices, so the offsets it feeds can only jump at a multiple of
+  // D -- or of D * C, where the next dimension out advances.
+  SmallVector<int64_t> getWrapPeriods(const SetVector<Operation *> &opChain) {
+    SmallVector<int64_t> periods;
+    for (auto *op : opChain) {
+      if (!isa<arith::DivSIOp, arith::RemSIOp>(op))
+        continue;
+      int64_t modulus = getConstIntVal(op->getOperand(1));
+      if (modulus <= 1)
+        continue;
+      // Divisors already applied to the value this op consumes: the index
+      // reconstruction divides the linear index down one dimension at a time.
+      int64_t divisor = 1;
+      Operation *lhsOp = op->getOperand(0).getDefiningOp();
+      while (auto divOp = dyn_cast_or_null<arith::DivSIOp>(lhsOp)) {
+        int64_t step = getConstIntVal(divOp.getRhs());
+        if (step <= 1)
+          break;
+        divisor *= step;
+        lhsOp = divOp.getLhs().getDefiningOp();
+      }
+      periods.emplace_back(divisor);
+      periods.emplace_back(divisor * modulus);
+    }
+    return periods;
+  }
+
   SmallVector<MockData> getMockDataItems(SetVector<Operation *> opChain) {
-    auto getProgramIdMockVals = []() {
-      SmallVector<int> mockVals(12);
+    // The mocked program ids cover the physical cluster count, so the sampled
+    // linear index only reaches numMockProgramIds * <program id stride>. The
+    // launcher wraps the kernel in a cluster loop, which makes
+    // tt.get_program_id the *logical* tile id, so a wider grid can wrap an
+    // index reconstruction outside that window: every sampled tile then looks
+    // perfectly continuous and the gm2lm burst keeps reading past the wrap
+    // instead of restarting at the row the wrap points at. Sample the tiles
+    // that hold such a wrap too.
+    auto getExtraProgramIdMockVals = [&]() {
+      SmallVector<int> extraVals;
+      int64_t pidStride = getProgramIdStride(opChain);
+      if (pidStride <= 0)
+        return extraVals;
+      // Keep the mocked offsets far away from the int32 the mock walks them in.
+      int64_t maxPeriod = std::numeric_limits<int32_t>::max() / 4;
+      for (int64_t period : getWrapPeriods(opChain)) {
+        if (period <= 0 || period > maxPeriod)
+          continue;
+        int pid = period / pidStride;
+        if (pid < numMockProgramIds || llvm::is_contained(extraVals, pid))
+          continue; // already sampled by the dense range below
+        extraVals.emplace_back(pid);
+        if (extraVals.size() == maxExtraProgramIds)
+          break;
+      }
+      llvm::sort(extraVals);
+      return extraVals;
+    };
+
+    auto getProgramIdMockVals = [&]() {
+      SmallVector<int> mockVals(numMockProgramIds);
       std::iota(mockVals.begin(), mockVals.end(), 0);
+      for (int extraVal : getExtraProgramIdMockVals())
+        mockVals.emplace_back(extraVal);
       return mockVals;
     };
 


### PR DESCRIPTION
OffsetAnalysis decides a gm2lm's offsetState by evaluating its offset chain for mocked program ids 0..11, the physical cluster count. The launcher wraps the kernel body in a cluster loop, so tt.get_program_id is the logical tile id and a launch may use far more tiles than that: with tile_size 8192 the sampled linear index only ever reaches 12 * 8192 = 98304. An index reconstruction of the form i = (idx / D) % C holds its value for D consecutive indices, so the offsets it feeds can only jump at a multiple of D. Once D exceeds the sampled window every mocked tile looks strictly +1 and the load is stamped Continuous (1), which lets the lowering issue one burst DMA per core chunk.

A rank-6 pointwise copy over a view whose input stride on one axis is 0 -- what repeat_interleave(x, 2, dim=0) lowers to for shape (16, 7, 57, 32, 29) -- walks the 6D space [16, 2, 7, 57, 32, 29] and restarts its input offsets every D = 7*57*32*29 = 370272 elements, while the store offsets stay globally contiguous. That launch is 1452 tiles, so the first wrap lands in tile 45, well outside the mocked range. The burst then keeps reading past the wrap instead of restarting at the row the offsets point back to, and every core chunk that straddles a wrap loses its tail: 128 - (D * (2k + 1) % 128) elements, 32 or 96 per wrap and 1024 in total across the 16 wraps, all on odd dim0 positions of the output.

Walk the offset chain for the constant divisor of every arith.remsi/arith.divsi, accumulate it into the wrap period D of the dimension each one extracts, and add the tiles that contain idx = D and idx = D * C to the mocked program ids, capped at four extra samples. An access that is genuinely contiguous shows no jump when evaluated there and stays Continuous, so it keeps its burst; this load is now reported LocallyContinuous with an unfixed row stride and reads the correct rows.

Verified on KL3 (xpu3): the copy above returns 0 wrong elements out of 11848704, whereas the same tree without this change mismatches on 1023 of them (one of the 1024 affected positions happens to hold a coincidentally equal value). The store of the same kernel is still stamped Continuous, and dim=1 on the same shape goes from 7135 wrong elements to 0.

<!-- PR Title Format:
[TLE][BUILD][TEST][CI/CD][DOC][PROTON][BACKEND][FLIR] Brief description
[LANGUAGE][AUTOTUNER][LAYOUT][PIPELINE][WarpSpecialization] Brief description
Do not set the following title tags: [FEATURE][BUG][FixBug][Refine] ...
-->
